### PR TITLE
Don't generate transactions with amount 0

### DIFF
--- a/src/core/payouts.ts
+++ b/src/core/payouts.ts
@@ -2,7 +2,7 @@ import { Block } from "./queries";
 import { StakingKey } from "./stakes";
 
 export async function getPayouts(blocks: Block[], stakers: StakingKey[], totalStake: number, commissionRate: number, transactionFee: number):
-  Promise<[payoutJson: PayoutTransaction[], storePayout: PayoutDetails[], payoutFileString: string, blocksIncluded: number[], allBlocksTotalRewards: number, allBlocksTotalPoolFees: number, totalPayout: number]> {
+  Promise<[payoutJson: PayoutTransaction[], storePayout: PayoutDetails[], blocksIncluded: number[], allBlocksTotalRewards: number, allBlocksTotalPoolFees: number, totalPayout: number]> {
 
   // Initialize some stuff
   let allBlocksTotalRewards = 0;
@@ -98,18 +98,19 @@ export async function getPayouts(blocks: Block[], stakers: StakingKey[], totalSt
 
   let payoutJson: PayoutTransaction[] = [];
   let totalPayout = 0;
-  let payoutFileString: string = "(";
   stakers.forEach((staker: StakingKey) => {
-    payoutJson.push({
-      publicKey: staker.publicKey,
-      amount: staker.total,
-      fee: transactionFee
-    });
-    totalPayout += staker.total;
+    const amount = staker.total;
+    if (amount > 0) {
+      payoutJson.push({
+        publicKey: staker.publicKey,
+        amount: amount,
+        fee: transactionFee
+      });
+      totalPayout += amount;
+    }
   });
-  payoutFileString += ")";
 
-  return [payoutJson, storePayout, payoutFileString, blocksIncluded, allBlocksTotalRewards, allBlocksTotalPoolFees, totalPayout];
+  return [payoutJson, storePayout, blocksIncluded, allBlocksTotalRewards, allBlocksTotalPoolFees, totalPayout];
 }
 
 export type PayoutDetails = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ async function main() {
     
     // run the payout calculation for those blocks
     const ledgerBlocks = blocks.filter(x => x.stakingledgerhash == ledgerHash);
-    const [ledgerPayouts, ledgerStorePayout, payoutFileString, blocksIncluded, allBlocksTotalRewards, allBlocksTotalPoolFees, totalPayout] = await getPayouts(ledgerBlocks, stakers, totalStake, commissionRate, transactionFee);
+    const [ledgerPayouts, ledgerStorePayout, blocksIncluded, allBlocksTotalRewards, allBlocksTotalPoolFees, totalPayout] = await getPayouts(ledgerBlocks, stakers, totalStake, commissionRate, transactionFee);
     payouts.push(...ledgerPayouts);
     storePayout.push(...ledgerStorePayout);
 
@@ -69,7 +69,7 @@ async function main() {
     console.log(`We won these blocks: ${blocksIncluded}`);
     console.log(`We are paying out based on total rewards of ${allBlocksTotalRewards} nanomina in this window.`);
     console.log(`That is ${allBlocksTotalRewards / 1000000000} mina`);
-    console.log(`The Pool Fee is is ${allBlocksTotalPoolFees / 1000000000} mina`);
+    console.log(`The Pool Fee is ${allBlocksTotalPoolFees / 1000000000} mina`);
     console.log(`Total Payout should be ${(allBlocksTotalRewards) - (allBlocksTotalPoolFees)} nanomina or ${((allBlocksTotalRewards) - (allBlocksTotalPoolFees)) / 1000000000} mina`)
     console.log(`The Total Payout is actually: ${totalPayout} nm or ${totalPayout / 1000000000} mina`)
   })).then(()=>{


### PR DESCRIPTION
Closes #20.

The transactions are not generated, but the payout details are still saved for future querying.

It's worth noting that the handling of #10 already solved this problem in some cases as a side effect, since transactions won't be generated if there aren't any validated blocks. Doesn't hurt to have this protection in any case.


