### PR TITLE
Correcting maxHeight for GraphQL query

### DIFF
--- a/src/core/dataprovider-minaexplorer/block-queries-gql.ts
+++ b/src/core/dataprovider-minaexplorer/block-queries-gql.ts
@@ -104,7 +104,7 @@ export async function getBlocksFromMinaExplorer (key: string, minHeight: number,
     {
       creator: key,
       blockHeight_gte: minHeight,
-      blockHeight_lte: (maxHeight - minHeight)
+      blockHeight_lte: maxHeight
     },
     graphqlEndpoint
   );


### PR DESCRIPTION
Looks like this should just be maxHeight? Tested this and works as expected e.g. `npm run payout -- -m=5000 -x=5150`