### PR TITLE
33 34 separate payout addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ The private key value can be retrieved from a pk file by running the mina advanc
     mina ledger hash --ledger-file staking-epoch-ledger.json | xargs -I % cp staking-epoch-ledger.json %.json
     mina ledger hash --ledger-file next-epoch-ledger.json | xargs -I % cp next-epoch-ledger.json %.json
     ```
+ 
+## Handling special accounts - suppressing or redirecting payouts 
+You can control whether payouts for a specific key should be skipped or redirected to another key. This is configured with a file named ".substitutePayTo" which should be placed in the src/data directory.  
+The file is pipe-delimited and contains 2 columns - the first column is the public key to consider, and the second is either the keyword "EXCLUDE", or the payout address to redirect payments to.
+- Public Key|EXCLUDE
+- Public Key|Redirected To Public Key
+
+In the example content below, the first row would cause any payouts to the first key to not be sent. This may be useful for the pool operator's keys. The second row would cause any payouts to the key ending in WCvh to be sent instead to the key ending in Ez3yB. This is useful for redirecting new tokens that would be paid to a locked account to go to an unlocked account instead. 
+
+    ```
+    B62qkBqSkXgkirtU3n8HJ9YgwHh3vUD6kGJ5ZRkQYGNPeL5xYL2tL1L|EXCLUDE
+    B62qinpqDF7ongjhpvJLz7QBsExP1BkpceED6GuThYYbSVSbk1nWCvh|B62qoigHEtJCoZ5ekbGHWyr9hYfc6fkZ2A41h9vvVZuvty9amzEz3yB
+    ```
+
+To enable these features, create a file src/data/.substitutePayTo and configure according to your situation.  
 
 # Running the script
 

--- a/src/core/dataprovider-archivedb/block-queries-sql.ts
+++ b/src/core/dataprovider-archivedb/block-queries-sql.ts
@@ -86,7 +86,7 @@ const getNullParentsQuery = `
   SELECT height FROM blocks WHERE parent_id is null AND height >= $1 AND height <= $2
 `;
 
-export async function getLatestHeightFromArchive () {
+export async function getLatestHeight () {
   const result = await db.one<height>(`
         SELECT MAX(height) AS height FROM public.blocks
     `);
@@ -103,7 +103,7 @@ async function getNullParents(minHeight: number, maxHeight: number) {
   return heights.map(x=> x.height);
 }
 
-export async function getBlocksFromArchive (key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
+export async function getBlocks (key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
   let blocks: Blocks = await db.any(blockQuery, [key, minHeight, maxHeight]);
 
   const missingHeights = await getHeightMissing(minHeight, maxHeight);

--- a/src/core/dataprovider-archivedb/block-queries-sql.ts
+++ b/src/core/dataprovider-archivedb/block-queries-sql.ts
@@ -93,18 +93,27 @@ export async function getLatestHeightFromArchive () {
   return result.height;
 }
 
-export async function getHeightMissing(minHeight: number, maxHeight: number) {
+async function getHeightMissing(minHeight: number, maxHeight: number) {
   const heights: Array<height> = await db.any(getHeightsMissingQuery, [minHeight, maxHeight]);
   return heights.map(x=> x.height);
 }
 
-export async function getNullParents(minHeight: number, maxHeight: number) {
+async function getNullParents(minHeight: number, maxHeight: number) {
   const heights: Array<height> = await db.any(getNullParentsQuery, [minHeight, maxHeight]);
   return heights.map(x=> x.height);
 }
 
 export async function getBlocksFromArchive (key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
   let blocks: Blocks = await db.any(blockQuery, [key, minHeight, maxHeight]);
+
+  const missingHeights = await getHeightMissing(minHeight, maxHeight);
+  if ((minHeight === 0 && (missingHeights.length > 1 || missingHeights[0] != 0)) || (minHeight > 0 && missingHeights.length > 0)) {
+    throw new Error(`Archive database is missing blocks in the specified range. Import them and try again. Missing blocks were: ${JSON.stringify(missingHeights)}`);
+  }
+  const nullParents = await getNullParents(minHeight, maxHeight);
+  if ((minHeight === 0 && (nullParents.length > 1 || nullParents[0] != 1)) || (minHeight > 0 && nullParents.length > 0)) {
+    throw new Error(`Archive database has null parents in the specified range. Import them and try again. Blocks with null parents were: ${JSON.stringify(nullParents)}`);
+  }
 
   const blockFile = `${__dirname}/../../data/.paidblocks`;
 

--- a/src/core/dataprovider-archivedb/staking-ledger-json-file.ts
+++ b/src/core/dataprovider-archivedb/staking-ledger-json-file.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 
 // for a given key, find all the stakers delegating to the provided public key (according to the provided epoch staking ledger)
 // determine when key will be unlocked and eligible for supercharged coinbase awards
-export function getStakesFromFile (ledgerHash: string, key: string): [Stake[], number] {
+export function getStakes (ledgerHash: string, key: string): [Stake[], number] {
   let totalStakingBalance: number = 0;
   // get the stakes from staking ledger json
   // TODO: this might need to be reworked for large files

--- a/src/core/dataprovider-minaexplorer/block-queries-gql.ts
+++ b/src/core/dataprovider-minaexplorer/block-queries-gql.ts
@@ -87,7 +87,7 @@ query LatestHeight {
   }
 }`
 
-export async function getLatestHeightFromMinaExplorer () {
+export async function getLatestHeight () {
   const { errors, data } = await fetchGraphQL(
     tipQuery,
     'LatestHeight',
@@ -96,7 +96,7 @@ export async function getLatestHeightFromMinaExplorer () {
   return (data.blocks[0].blockHeight);
 }
 
-export async function getBlocksFromMinaExplorer (key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
+export async function getBlocks (key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
   let flatBlocks: Blocks = []
   const { errors, data } = await fetchGraphQL(
     blockQuery,

--- a/src/core/dataprovider-minaexplorer/staking-ledger-gql.ts
+++ b/src/core/dataprovider-minaexplorer/staking-ledger-gql.ts
@@ -22,7 +22,7 @@ query stakingLedger( $ledgerHash: String, $delegate: String) {
 
 // for a given key, find all the stakers delegating to the provided public key (according to the provided epoch staking ledger)
 // determine when key will be unlocked and eligible for supercharged coinbase awards
-export async function getStakesFromMinaExplorer (ledgerHash: string, key: string): Promise<[Stake[], number]> {
+export async function getStakes (ledgerHash: string, key: string): Promise<[Stake[], number]> {
   let totalStakingBalance: number = 0;
   let stakers: Stake[] = [];
   const { errors, data } = await fetchGraphQL(

--- a/src/core/payout-calculator.ts
+++ b/src/core/payout-calculator.ts
@@ -1,35 +1,53 @@
 import { Block, Stake } from "./dataprovider-types";
 import { stakeIsLocked } from "./staking-ledger-util";
+import parse from "csv-parse";
+import fs from "fs";
+
 // per foundation and o1 rules, the maximum fee is 5%, excluding fees and supercharged coinbase
 // see https://minaprotocol.com/docs/advanced/foundation-delegation-program
-const npsCommissionRate = 0.05
+const npsCommissionRate = 0.05;
 
-export async function getPayouts (blocks: Block[], stakers: Stake[], totalStake: number, commissionRate: number):
-  Promise<[payoutJson: PayoutTransaction[], storePayout: PayoutDetails[], blocksIncluded: number[], totalPayout: number]> {
-
+export async function getPayouts(
+  blocks: Block[],
+  stakers: Stake[],
+  totalStake: number,
+  commissionRate: number
+): Promise<
+  [
+    payoutJson: PayoutTransaction[],
+    storePayout: PayoutDetails[],
+    blocksIncluded: number[],
+    totalPayout: number
+  ]
+> {
   // Initialize some stuff
   let blocksIncluded: number[] = [];
   let storePayout: PayoutDetails[] = [];
 
   // for each block, calculate the effective stake of each staker
   blocks.forEach((block: Block) => {
-
     // Keep a log of all blocks we processed
     blocksIncluded.push(block.blockheight);
 
-    if (typeof (block.coinbase) === 'undefined' || block.coinbase == 0) {
+    if (typeof block.coinbase === "undefined" || block.coinbase == 0) {
       // no coinbase, don't need to do anything
     } else {
-
       const winner = getWinner(stakers, block);
 
       let sumEffectiveCommonPoolStakes = 0;
       let sumEffectiveNPSPoolStakes = 0;
-      let effectivePoolStakes: { [key: string]: { npsStake: number, commonStake: number } } = {};
+      let effectivePoolStakes: {
+        [key: string]: { npsStake: number; commonStake: number };
+      } = {};
 
       const transactionFees = block.usercommandtransactionfees || 0;
-      const totalRewards = block.coinbase + block.feetransfertoreceiver - block.feetransferfromcoinbase;
-      const totalNPSPoolRewards = stakeIsLocked(winner, block) ? block.coinbase : block.coinbase / 2;
+      const totalRewards =
+        block.coinbase +
+        block.feetransfertoreceiver -
+        block.feetransferfromcoinbase;
+      const totalNPSPoolRewards = stakeIsLocked(winner, block)
+        ? block.coinbase
+        : block.coinbase / 2;
       const totalCommonPoolRewards = totalRewards - totalNPSPoolRewards;
 
       // Determine the supercharged discount for the block
@@ -44,34 +62,56 @@ export async function getPayouts (blocks: Block[], stakers: Stake[], totalStake:
         let effectiveCommonStake = 0;
         // common stake stays at 0 for NPS shares - they do not participate with the common in fees or supercharged block coinbase
         if (staker.shareClass == "Common") {
-          effectiveCommonStake = !stakeIsLocked(staker, block) ? staker.stakingBalance * (2 - superchargedWeightingDiscount) : staker.stakingBalance;
-          totalUnweightedCommonStake += staker.stakingBalance
+          effectiveCommonStake = !stakeIsLocked(staker, block)
+            ? staker.stakingBalance * (2 - superchargedWeightingDiscount)
+            : staker.stakingBalance;
+          totalUnweightedCommonStake += staker.stakingBalance;
         }
         sumEffectiveNPSPoolStakes += effectiveNPSStake;
         sumEffectiveCommonPoolStakes += effectiveCommonStake;
-        effectivePoolStakes[staker.publicKey] = { npsStake: effectiveNPSStake, commonStake: effectiveCommonStake };
+        effectivePoolStakes[staker.publicKey] = {
+          npsStake: effectiveNPSStake,
+          commonStake: effectiveCommonStake,
+        };
       });
 
       // Sense check the effective pool stakes must be at least equal to total_staking_balance and less than 2x
       if (sumEffectiveNPSPoolStakes != totalStake) {
-        throw new Error('NPS Share must be equal to total staked amount');
+        throw new Error("NPS Share must be equal to total staked amount");
       }
       if (sumEffectiveCommonPoolStakes > totalUnweightedCommonStake * 2) {
-        throw new Error('Common weighted share must not be greater than 2x total common stake');
+        throw new Error(
+          "Common weighted share must not be greater than 2x total common stake"
+        );
       }
 
       stakers.forEach((staker: Stake) => {
-        const effectiveNPSPoolWeighting = effectivePoolStakes[staker.publicKey].npsStake / sumEffectiveNPSPoolStakes;
-        const effectiveCommonPoolWeighting = effectivePoolStakes[staker.publicKey].commonStake / sumEffectiveCommonPoolStakes;
+        const effectiveNPSPoolWeighting =
+          effectivePoolStakes[staker.publicKey].npsStake /
+          sumEffectiveNPSPoolStakes;
+        const effectiveCommonPoolWeighting =
+          effectivePoolStakes[staker.publicKey].commonStake /
+          sumEffectiveCommonPoolStakes;
 
         let blockTotal = 0;
         if (staker.shareClass == "Common") {
           blockTotal =
-            Math.floor((1 - commissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting) +
-            Math.floor((1 - commissionRate) * totalCommonPoolRewards * effectiveCommonPoolWeighting);
+            Math.floor(
+              (1 - commissionRate) *
+                totalNPSPoolRewards *
+                effectiveNPSPoolWeighting
+            ) +
+            Math.floor(
+              (1 - commissionRate) *
+                totalCommonPoolRewards *
+                effectiveCommonPoolWeighting
+            );
         } else if (staker.shareClass == "NPS") {
-          blockTotal =
-            Math.floor((1 - npsCommissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting);
+          blockTotal = Math.floor(
+            (1 - npsCommissionRate) *
+              totalNPSPoolRewards *
+              effectiveNPSPoolWeighting
+          );
         }
 
         staker.total += blockTotal;
@@ -86,9 +126,11 @@ export async function getPayouts (blocks: Block[], stakers: Stake[], totalStake:
           stateHash: block.statehash,
           stakingBalance: staker.stakingBalance,
           effectiveNPSPoolWeighting: effectiveNPSPoolWeighting,
-          effectiveNPSPoolStakes: effectivePoolStakes[staker.publicKey].npsStake,
+          effectiveNPSPoolStakes:
+            effectivePoolStakes[staker.publicKey].npsStake,
           effectiveCommonPoolWeighting: effectiveCommonPoolWeighting,
-          effectiveCommonPoolStakes: effectivePoolStakes[staker.publicKey].commonStake,
+          effectiveCommonPoolStakes:
+            effectivePoolStakes[staker.publicKey].commonStake,
           sumEffectiveNPSPoolStakes: sumEffectiveNPSPoolStakes,
           sumEffectiveCommonPoolStakes: sumEffectiveCommonPoolStakes,
           superchargedWeightingDiscount: superchargedWeightingDiscount,
@@ -119,8 +161,8 @@ export async function getPayouts (blocks: Block[], stakers: Stake[], totalStake:
   return [payoutJson, storePayout, blocksIncluded, totalPayout];
 }
 
-function getWinner (stakers: Stake[], block: Block): Stake {
-  const winners = stakers.filter(x => x.publicKey == block.winnerpublickey);
+function getWinner(stakers: Stake[], block: Block): Stake {
+  const winners = stakers.filter((x) => x.publicKey == block.winnerpublickey);
   if (winners.length != 1) {
     throw new Error("Should have exactly 1 winner.");
   }
@@ -128,30 +170,66 @@ function getWinner (stakers: Stake[], block: Block): Stake {
 }
 
 export type PayoutDetails = {
-  publicKey: string,
-  blockHeight: number,
-  globalSlot: number,
-  publicKeyUntimedAfter: number,
-  shareClass: "NPS" | "Common",
-  stateHash: string,
-  effectiveNPSPoolWeighting: number,
-  effectiveNPSPoolStakes: number,
-  effectiveCommonPoolWeighting: number,
-  effectiveCommonPoolStakes: number,
-  stakingBalance: number,
-  sumEffectiveNPSPoolStakes: number,
-  sumEffectiveCommonPoolStakes: number,
-  superchargedWeightingDiscount: number,
-  dateTime: number,
-  coinbase: number,
-  totalRewards: number,
-  totalRewardsNPSPool: number,
-  totalRewardsCommonPool: number,
-  payout: number
+  publicKey: string;
+  blockHeight: number;
+  globalSlot: number;
+  publicKeyUntimedAfter: number;
+  shareClass: "NPS" | "Common";
+  stateHash: string;
+  effectiveNPSPoolWeighting: number;
+  effectiveNPSPoolStakes: number;
+  effectiveCommonPoolWeighting: number;
+  effectiveCommonPoolStakes: number;
+  stakingBalance: number;
+  sumEffectiveNPSPoolStakes: number;
+  sumEffectiveCommonPoolStakes: number;
+  superchargedWeightingDiscount: number;
+  dateTime: number;
+  coinbase: number;
+  totalRewards: number;
+  totalRewardsNPSPool: number;
+  totalRewardsCommonPool: number;
+  payout: number;
 };
 
 export type PayoutTransaction = {
-  publicKey: string,
-  amount: number,
-  fee: number,
+  publicKey: string;
+  amount: number;
+  fee: number;
 };
+
+export async function substituteAndExcludePayToAddresses(
+  transactions: PayoutTransaction[]
+): Promise<PayoutTransaction[]> {
+  // load susbtitutes from file
+  // expects format:
+  //  B62... | B62...
+  //  B62... | EXCLUDE
+  // remove excluded addresses
+  // swap mapped addresses
+  const path = require("path");
+  const substitutePayToFile = path.join("src", "data", ".substitutePayTo");
+  const filterPayouts = () => {
+    return new Promise((resolve, reject) => {
+      fs.createReadStream(substitutePayToFile)
+        .pipe(parse({ delimiter: "|" }))
+        .on("data", (record) => {
+          transactions = transactions
+            .filter(
+              (transaction) =>
+                !(transaction.publicKey == record[0] && record[1] == "EXCLUDE")
+            )
+            .map((t) => {
+              if (t.publicKey == record[0]) t.publicKey = record[1];
+              return t;
+            });
+        })
+        .on("end", resolve)
+        .on("error", reject);
+    });
+  };
+  if (fs.existsSync(substitutePayToFile)) {
+    await filterPayouts();
+  }
+  return transactions;
+}

--- a/src/core/send-payments.ts
+++ b/src/core/send-payments.ts
@@ -1,6 +1,7 @@
 import { signPayment, keypair, signed, payment } from "@o1labs/client-sdk";
 import { PayoutTransaction } from "./payout-calculator";
 import fs from "fs";
+import parse from "csv-parse";
 import { fetchGraphQL } from "../infrastructure/graphql";
 
 const graphqlEndpoint = process.env.SEND_PAYMENT_GRAPHQL_ENDPOINT || "https://localhost:3085";

--- a/src/core/send-payments.ts
+++ b/src/core/send-payments.ts
@@ -1,7 +1,6 @@
 import { signPayment, keypair, signed, payment } from "@o1labs/client-sdk";
 import { PayoutTransaction } from "./payout-calculator";
 import fs from "fs";
-import parse from "csv-parse";
 import { fetchGraphQL } from "../infrastructure/graphql";
 
 const graphqlEndpoint = process.env.SEND_PAYMENT_GRAPHQL_ENDPOINT || "https://localhost:3085";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { getPayouts, PayoutDetails, PayoutTransaction } from "./core/payout-calculator";
 import { getStakesFromFile } from "./core/dataprovider-archivedb/staking-ledger-json-file";
-import { getBlocksFromArchive, getLatestHeightFromArchive, getHeightMissing, getNullParents  } from "./core/dataprovider-archivedb/block-queries-sql";
+import { getBlocksFromArchive, getLatestHeightFromArchive } from "./core/dataprovider-archivedb/block-queries-sql";
 import { getBlocksFromMinaExplorer, getLatestHeightFromMinaExplorer } from './core/dataprovider-minaexplorer/block-queries-gql'
 import { getStakesFromMinaExplorer } from './core/dataprovider-minaexplorer/staking-ledger-gql'
 import { Blocks } from "./core/dataprovider-types";
@@ -44,14 +44,6 @@ async function main () {
 
   let blocks: Blocks = [];
   if (blockDataSource === 'ARCHIVEDB'){
-    const missingHeights = await getHeightMissing(minimumHeight, maximumHeight);
-    if ((minimumHeight === 0 && (missingHeights.length > 1 || missingHeights[0] != 0)) || (minimumHeight > 0 && missingHeights.length > 0)) {
-      throw new Error(`Archive database is missing blocks in the specified range. Import them and try again. Missing blocks were: ${JSON.stringify(missingHeights)}`);
-    }
-    const nullParents = await getNullParents(minimumHeight, maximumHeight);
-    if ((minimumHeight === 0 && (nullParents.length > 1 || nullParents[0] != 1)) || (minimumHeight > 0 && nullParents.length > 0)) {
-      throw new Error(`Archive database has null parents in the specified range. Import them and try again. Blocks with null parents were: ${JSON.stringify(nullParents)}`);
-    }
     blocks = await getBlocksFromArchive(stakingPoolPublicKey, minimumHeight, maximumHeight)
   } else if (blockDataSource == "MINAEXPLORER") {
     blocks = await getBlocksFromMinaExplorer(stakingPoolPublicKey, minimumHeight, maximumHeight)

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ async function main () {
   const stakingPoolPublicKey: string = process.env.POOL_PUBLIC_KEY || "";
   const payoutMemo: string = process.env.POOL_MEMO || "";
   const payorSendTransactionFee = (Number(process.env.SEND_TRANSACTION_FEE) || 0) * 1000000000;
+  // TODO: validate and then move this downt to send-payments to consolidated client-sdk 
+  // TODO: introduce -network flag to support test, pass to send-payments
   let senderKeys: keypair = {
     privateKey: process.env.SEND_PRIVATE_KEY || "",
     publicKey: process.env.SEND_PUBLIC_KEY || ""


### PR DESCRIPTION
Cleans up data provider usage to simplify and eliminate database dependency when running against mina explorer.

Implements new features to redirect payments from one key to another key (support for sending awards due to a locked account to an unlocked account instead) and excluding keys from being paid at all (support for leaving pool owner funds alone and not paying them back to the pools delegators.)

Closes #33 and #34 

Still left to the pool owner to setup these redirects manually. In the future would prefer to have a signed message to auto-configure this.....