### PR TITLE
58 supercharged handler update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 _Inspired by [minaexplorer - mina-payout-script](https://github.com/garethtdavies/mina-payout-script)_
 This started out as a port from the original, but has morphed a fair amount. With major updates we will try to compare the output with MinaExplorer's approach, but we are not necessarily committed to maintaining parity.
-The main difference is that Mina Explorer spreads an unlocked key's supercharged award across the entire epoch when it will unlock during the epoch. mina-pool-payout will simply attribute supercharged rewards when a key unlocks.
-Other than that known difference, the payout rules are the same. In our last parity test (on 3/21/2021), both approaches generated exactly the same payout calculations.
+There are now two main differences vs. the original Mina Explorer implementation:
+- mina-payout-script spreads an unlocked key's weighted supercharged award across the entire epoch if it will unlock at any point during the epoch. mina-pool-payout will only supercharge an account after it is unlocked.
+- Additionally, mina-pool-payout will (as of 6/12/21) reserve supercharged rewards entirely for unlocked keys versus spreading their supercharged amount across normal coinbase blocks as well. This will result in more variability in unlocked payout using mina-pool-payout.
 
 # Dependencies
 - This code uses language features of Typescript v3.7 and Node 14.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # mina-pool-payout
 
 _Inspired by [minaexplorer - mina-payout-script](https://github.com/garethtdavies/mina-payout-script)_
-This started out as a port from the original, but has morphed a fair amount. With major updates we will try to compare the output with MinaExplorer's approach, but we are not necessarily committed to maintaining parity.
-There are now two main differences vs. the original Mina Explorer implementation:
+This started out as a port from the original, but has morphed a fair amount. As of PR 59, direct comparisons between the two are no longer expected to produce the same results. The main differences vs. the Mina Explorer implementation include:
 - mina-payout-script spreads an unlocked key's weighted supercharged award across the entire epoch if it will unlock at any point during the epoch. mina-pool-payout will only supercharge an account after it is unlocked.
-- Additionally, mina-pool-payout will (as of 6/12/21) reserve supercharged rewards entirely for unlocked keys versus spreading their supercharged amount across normal coinbase blocks as well. This will result in more variability in unlocked payout using mina-pool-payout.
+- mina-pool-payout will (as of PR 59) reserve supercharged rewards entirely for unlocked keys versus spreading the supercharged award across normal coinbase blocks as well. This will result in more variability in unlocked payout versus mina-payout-script.
 
 # Dependencies
 - This code uses language features of Typescript v3.7 and Node 14.
-- The host this runs from will either require access to a Mina Archive database, or to the MinaExplorer grapql API.
+- The host this runs from will either require access to a Mina Archive database, or to the MinaExplorer graphql API.
 - If payments are to be sent, access to a graphql endpoint that can send signed transactions is required.
 
 # Operational Overview

--- a/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
+++ b/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
@@ -155,6 +155,7 @@ export async function getPayouts(
           totalRewards: totalRewards,
           totalRewardsNPSPool: totalNPSPoolRewards,
           totalRewardsCommonPool: totalCommonPoolRewards,
+          totalRewardsSuperchargedPool: totalSuperchargedPoolRewards,
           payout: blockTotal,
         });
       });
@@ -208,6 +209,7 @@ export type PayoutDetails = {
   totalRewards: number;
   totalRewardsNPSPool: number;
   totalRewardsCommonPool: number;
+  totalRewardsSuperchargedPool: number;
   payout: number;
 };
 

--- a/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
+++ b/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
@@ -90,15 +90,18 @@ export async function getPayouts(
       }
 
       stakers.forEach((staker: Stake) => {
-        const effectiveNPSPoolWeighting =
-          effectivePoolStakes[staker.publicKey].npsStake /
-          sumEffectiveNPSPoolStakes;
-        const effectiveCommonPoolWeighting =
-          effectivePoolStakes[staker.publicKey].commonStake /
-          sumEffectiveCommonPoolStakes;
-        const effectiveSuperchargedPoolWeighting =
-          effectivePoolStakes[staker.publicKey].superchargedStake /
-          sumEffectiveSuperchargedPoolStakes;
+        const effectiveNPSPoolWeighting = (sumEffectiveNPSPoolStakes > 0)
+          ? effectivePoolStakes[staker.publicKey].npsStake /
+          sumEffectiveNPSPoolStakes
+          : 0;
+        const effectiveCommonPoolWeighting = (sumEffectiveCommonPoolStakes > 0)
+          ? effectivePoolStakes[staker.publicKey].commonStake /
+          sumEffectiveCommonPoolStakes
+          : 0;
+        const effectiveSuperchargedPoolWeighting = (sumEffectiveSuperchargedPoolStakes > 0)
+          ? effectivePoolStakes[staker.publicKey].superchargedStake /
+          sumEffectiveSuperchargedPoolStakes
+          : 0;
 
         let blockTotal = 0;
         if (staker.shareClass == "Common") {
@@ -124,7 +127,7 @@ export async function getPayouts(
               totalNPSPoolRewards *
               effectiveNPSPoolWeighting
           );
-        }
+        } else throw new Error('Staker share class is unknown');
 
         staker.total += blockTotal;
 

--- a/src/core/payout-calculator/payout-calculator-original.ts
+++ b/src/core/payout-calculator/payout-calculator-original.ts
@@ -1,0 +1,235 @@
+import { Block, Stake } from "../dataprovider-types";
+import { stakeIsLocked } from "../staking-ledger-util";
+import parse from "csv-parse";
+import fs from "fs";
+
+// per foundation and o1 rules, the maximum fee is 5%, excluding fees and supercharged coinbase
+// see https://minaprotocol.com/docs/advanced/foundation-delegation-program
+const npsCommissionRate = 0.05;
+
+export async function getPayouts(
+  blocks: Block[],
+  stakers: Stake[],
+  totalStake: number,
+  commissionRate: number
+): Promise<
+  [
+    payoutJson: PayoutTransaction[],
+    storePayout: PayoutDetails[],
+    blocksIncluded: number[],
+    totalPayout: number
+  ]
+> {
+  // Initialize some stuff
+  let blocksIncluded: number[] = [];
+  let storePayout: PayoutDetails[] = [];
+
+  // for each block, calculate the effective stake of each staker
+  blocks.forEach((block: Block) => {
+    // Keep a log of all blocks we processed
+    blocksIncluded.push(block.blockheight);
+
+    if (typeof block.coinbase === "undefined" || block.coinbase == 0) {
+      // no coinbase, don't need to do anything
+    } else {
+      const winner = getWinner(stakers, block);
+
+      let sumEffectiveCommonPoolStakes = 0;
+      let sumEffectiveNPSPoolStakes = 0;
+      let effectivePoolStakes: {
+        [key: string]: { npsStake: number; commonStake: number };
+      } = {};
+
+      const transactionFees = block.usercommandtransactionfees || 0;
+      const totalRewards =
+        block.coinbase +
+        block.feetransfertoreceiver -
+        block.feetransferfromcoinbase;
+      const totalNPSPoolRewards = stakeIsLocked(winner, block)
+        ? block.coinbase
+        : block.coinbase / 2;
+      const totalCommonPoolRewards = totalRewards - totalNPSPoolRewards;
+
+      // Determine the supercharged discount for the block
+      //  unlocked accounts will get a double share less this discount based on the ratio of fees : coinbase
+      //  unlocaked accounts generate extra coinbase, but if fees are significant, that coinbase would have a lower relative weight
+      const superchargedWeightingDiscount = transactionFees / block.coinbase;
+
+      let totalUnweightedCommonStake = 0;
+      // Determine the non-participating and common pool weighting for each staker
+      stakers.forEach((staker: Stake) => {
+        let effectiveNPSStake = staker.stakingBalance;
+        let effectiveCommonStake = 0;
+        // common stake stays at 0 for NPS shares - they do not participate with the common in fees or supercharged block coinbase
+        if (staker.shareClass == "Common") {
+          effectiveCommonStake = !stakeIsLocked(staker, block)
+            ? staker.stakingBalance * (2 - superchargedWeightingDiscount)
+            : staker.stakingBalance;
+          totalUnweightedCommonStake += staker.stakingBalance;
+        }
+        sumEffectiveNPSPoolStakes += effectiveNPSStake;
+        sumEffectiveCommonPoolStakes += effectiveCommonStake;
+        effectivePoolStakes[staker.publicKey] = {
+          npsStake: effectiveNPSStake,
+          commonStake: effectiveCommonStake,
+        };
+      });
+
+      // Sense check the effective pool stakes must be at least equal to total_staking_balance and less than 2x
+      if (sumEffectiveNPSPoolStakes != totalStake) {
+        throw new Error("NPS Share must be equal to total staked amount");
+      }
+      if (sumEffectiveCommonPoolStakes > totalUnweightedCommonStake * 2) {
+        throw new Error(
+          "Common weighted share must not be greater than 2x total common stake"
+        );
+      }
+
+      stakers.forEach((staker: Stake) => {
+        const effectiveNPSPoolWeighting =
+          effectivePoolStakes[staker.publicKey].npsStake /
+          sumEffectiveNPSPoolStakes;
+        const effectiveCommonPoolWeighting =
+          effectivePoolStakes[staker.publicKey].commonStake /
+          sumEffectiveCommonPoolStakes;
+
+        let blockTotal = 0;
+        if (staker.shareClass == "Common") {
+          blockTotal =
+            Math.floor(
+              (1 - commissionRate) *
+                totalNPSPoolRewards *
+                effectiveNPSPoolWeighting
+            ) +
+            Math.floor(
+              (1 - commissionRate) *
+                totalCommonPoolRewards *
+                effectiveCommonPoolWeighting
+            );
+        } else if (staker.shareClass == "NPS") {
+          blockTotal = Math.floor(
+            (1 - npsCommissionRate) *
+              totalNPSPoolRewards *
+              effectiveNPSPoolWeighting
+          );
+        }
+
+        staker.total += blockTotal;
+
+        // Store this data in a structured format for later querying and for the payment script, handled seperately
+        storePayout.push({
+          publicKey: staker.publicKey,
+          blockHeight: block.blockheight,
+          globalSlot: block.globalslotsincegenesis,
+          publicKeyUntimedAfter: staker.untimedAfterSlot,
+          shareClass: staker.shareClass,
+          stateHash: block.statehash,
+          stakingBalance: staker.stakingBalance,
+          effectiveNPSPoolWeighting: effectiveNPSPoolWeighting,
+          effectiveNPSPoolStakes:
+            effectivePoolStakes[staker.publicKey].npsStake,
+          effectiveCommonPoolWeighting: effectiveCommonPoolWeighting,
+          effectiveCommonPoolStakes:
+            effectivePoolStakes[staker.publicKey].commonStake,
+          sumEffectiveNPSPoolStakes: sumEffectiveNPSPoolStakes,
+          sumEffectiveCommonPoolStakes: sumEffectiveCommonPoolStakes,
+          superchargedWeightingDiscount: superchargedWeightingDiscount,
+          dateTime: block.blockdatetime,
+          coinbase: block.coinbase,
+          totalRewards: totalRewards,
+          totalRewardsNPSPool: totalNPSPoolRewards,
+          totalRewardsCommonPool: totalCommonPoolRewards,
+          payout: blockTotal,
+        });
+      });
+    }
+  });
+
+  let payoutJson: PayoutTransaction[] = [];
+  let totalPayout = 0;
+  stakers.forEach((staker: Stake) => {
+    const amount = staker.total;
+    if (amount > 0) {
+      payoutJson.push({
+        publicKey: staker.publicKey,
+        amount: amount,
+        fee: 0,
+      });
+      totalPayout += amount;
+    }
+  });
+  return [payoutJson, storePayout, blocksIncluded, totalPayout];
+}
+
+function getWinner(stakers: Stake[], block: Block): Stake {
+  const winners = stakers.filter((x) => x.publicKey == block.winnerpublickey);
+  if (winners.length != 1) {
+    throw new Error("Should have exactly 1 winner.");
+  }
+  return winners[0];
+}
+
+export type PayoutDetails = {
+  publicKey: string;
+  blockHeight: number;
+  globalSlot: number;
+  publicKeyUntimedAfter: number;
+  shareClass: "NPS" | "Common";
+  stateHash: string;
+  effectiveNPSPoolWeighting: number;
+  effectiveNPSPoolStakes: number;
+  effectiveCommonPoolWeighting: number;
+  effectiveCommonPoolStakes: number;
+  stakingBalance: number;
+  sumEffectiveNPSPoolStakes: number;
+  sumEffectiveCommonPoolStakes: number;
+  superchargedWeightingDiscount: number;
+  dateTime: number;
+  coinbase: number;
+  totalRewards: number;
+  totalRewardsNPSPool: number;
+  totalRewardsCommonPool: number;
+  payout: number;
+};
+
+export type PayoutTransaction = {
+  publicKey: string;
+  amount: number;
+  fee: number;
+};
+
+export async function substituteAndExcludePayToAddresses(
+  transactions: PayoutTransaction[]
+): Promise<PayoutTransaction[]> {
+  // load susbtitutes from file
+  // expects format:
+  //  B62... | B62...
+  //  B62... | EXCLUDE
+  // remove excluded addresses
+  // swap mapped addresses
+  const path = require("path");
+  const substitutePayToFile = path.join("src", "data", ".substitutePayTo");
+  const filterPayouts = () => {
+    return new Promise((resolve, reject) => {
+      fs.createReadStream(substitutePayToFile)
+        .pipe(parse({ delimiter: "|" }))
+        .on("data", (record) => {
+          transactions = transactions
+            .filter(
+              (transaction) =>
+                !(transaction.publicKey == record[0] && record[1] == "EXCLUDE")
+            )
+            .map((t) => {
+              if (t.publicKey == record[0]) t.publicKey = record[1];
+              return t;
+            });
+        })
+        .on("end", resolve)
+        .on("error", reject);
+    });
+  };
+  if (fs.existsSync(substitutePayToFile)) {
+    await filterPayouts();
+  }
+  return transactions;
+}

--- a/src/core/send-payments.ts
+++ b/src/core/send-payments.ts
@@ -1,5 +1,5 @@
 import { signPayment, keypair, signed, payment } from "@o1labs/client-sdk";
-import { PayoutTransaction } from "./payout-calculator";
+import { PayoutTransaction } from "./payout-calculator/payout-calculator-isolate-supercharge";
 import fs from "fs";
 import { fetchGraphQL } from "../infrastructure/graphql";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { getPayouts, PayoutDetails, PayoutTransaction, substituteAndExcludePayToAddresses } from "./core/payout-calculator";
+import { getPayouts, PayoutDetails, PayoutTransaction, substituteAndExcludePayToAddresses } from "./core/payout-calculator/payout-calculator-isolate-supercharge";
 import { Blocks } from "./core/dataprovider-types";
 import hash from "object-hash";
 import yargs, { boolean } from "yargs";


### PR DESCRIPTION
removes supercharged weighting in favor of dedicated supercharge pool
new payout waterfall is:

First 720 coinbase - pro rata to all delegators
Fees - pro rata to all except O1/MF
Next 720 coinbase - pro rata to all unlocked accounts (unlocked at the given block height)

Ran and compared old and new algorithm for past epochs and results are equivalent with expected distribution changes.

Old algorithm can still be run by changing send-payment.ts and index.ts headers to include payout-calculator-original instead of payout-calculator-isolate-supercharge.

Files moved & renamed so the PR comparison is not useful; manually compare payout-calculator-original.ts to payout-calculator-isolate-supercharge.ts to see deltas. 