### PR TITLE
adding new config parameter SEND_PAYOUT_THRESHOLD to suppress tiny payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Copy `sample.env` to `.env` and make the following changes within the `.env`:
 
 - Set `SEND_TRANSACTION_FEE` to the transaction fee for payout transactions. It is specified in the .env file in MINA, but will be translated to NANOMINA for the actual payment transactions. Double check that this is in Mina!
 
+- Set `SEND_PAYOUT_THRESHOLD` to a minimum threshold which payout amounts must exceed to be sent. Default is 0, and payout transaction amount must _exceed_ this number to be sent. Also specified in Mina!
+
 - Set `SEND_PRIVATE_KEY` to the sender private key
 The private key value can be retrieved from a pk file by running the mina advanced dump-keypair command, e.g.
 

--- a/sample.env
+++ b/sample.env
@@ -10,7 +10,9 @@ POOL_MEMO="payout from mina-pool-payout"
 
 # payout configuration
 # fee for transaction sends
-SEND_TRANSACTION_FEE=0.01
+SEND_TRANSACTION_FEE=0.001
+# new parameter for a payout threshold - payouts below this amount will automatically be suppressed
+SEND_PAYOUT_THRESHOLD=0.002
 # private key to sign payments
 # public key to send payments from
 SEND_PRIVATE_KEY=B62...

--- a/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
+++ b/src/core/payout-calculator/payout-calculator-isolate-supercharge.ts
@@ -223,7 +223,7 @@ export type PayoutTransaction = {
 };
 
 export async function substituteAndExcludePayToAddresses(
-  transactions: PayoutTransaction[]
+  transactions: PayoutTransaction[], payoutThreshold: number
 ): Promise<PayoutTransaction[]> {
   // load susbtitutes from file
   // expects format:
@@ -241,7 +241,10 @@ export async function substituteAndExcludePayToAddresses(
           transactions = transactions
             .filter(
               (transaction) =>
-                !(transaction.publicKey == record[0] && record[1] == "EXCLUDE")
+                (
+                  !(transaction.publicKey == record[0] && record[1] == "EXCLUDE") &&
+                  !(transaction.amount <= payoutThreshold)
+                )
             )
             .map((t) => {
               if (t.publicKey == record[0]) t.publicKey = record[1];

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ async function main () {
   const configuredMaximum = args.maxheight;
   const blockDataSource = process.env.BLOCK_DATA_SOURCE || 'ARCHIVEDB'
   const verbose = args.verbose;
+  const payoutThreshold = Number(process.env.SEND_PAYOUT_THRESHOLD) * 1000000000 || 0;
 
   if ( blockDataSource != "ARCHIVEDB" && blockDataSource != "MINAEXPLORER" ) {
     throw new Error ('Unkown Data Source')
@@ -96,7 +97,7 @@ async function main () {
     console.log(`before substitutions and exclusions`)
     console.table(transactions);
     const payoutHash = hash(storePayout, { algorithm: "sha256" });
-    transactions = await substituteAndExcludePayToAddresses ( transactions );
+    transactions = await substituteAndExcludePayToAddresses ( transactions, payoutThreshold );
     transactions.map((t) => {totalPayoutFundsNeeded += t.amount + t.fee});
     console.log(`after substitutions and exclusions`)
     console.table(transactions);


### PR DESCRIPTION
Adds a new configuration parameter SEND_PAYOUT_THRESHOLD 

Will suppress payouts where the payout amount is less than OR EQUAL TO the specified configuration alue.
Value is specified in MINA, _not nanomina_.

Closes #55 