### PR TITLE
Sort transaction details so hash is always the same

### DIFF
--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -71,6 +71,13 @@ export class PaymentBuilder implements IPaymentBuilder {
             console.log(`The Total Payout is: ${totalPayout} nm or ${totalPayout / 1000000000} mina`)
         })).then( async () => {
 
+            // added a sort because these payout details are hashed and need to be in a reliable order
+            storePayout.sort(function (p1: PayoutDetails, p2: PayoutDetails) {
+                if (p1.blockHeight + p1.publicKey < p2.blockHeight + p2.publicKey ) { return -1; }
+                if (p1.blockHeight + p1.publicKey > p2.blockHeight +  p2.publicKey) { return 1; }
+                return 0;
+            });
+
             let paymentProcess : PaymentProcess = { payouts, storePayout, maximumHeight, blocks, totalPayoutFundsNeeded: 0}
 
             return paymentProcess


### PR DESCRIPTION
Bug reported by Eddie B|FreshMina.
Running across epochs, unable to send transactions due to mismatched hash error.
Hash was never the same because of asynch behavior with data spanning epochs.
Resolved by adding a compound-key sort (block height + delegator public key).

Confirmed bug repro in main; confirmed bug free in branch.
Confirmed payout amounts are the same across main branch and this branch - as expected. Payment amounts were always correct; list order was causing different hashes to be generated.

Fringe benefit - hashes now reliably match across archive db and mina explorer data sources. This would allow even safer operation by using different data sources for the calculation vs. payout transmission runs.
