### PR TITLE
await config validity

### DIFF
--- a/src/core/payment/PaymentProcessor.ts
+++ b/src/core/payment/PaymentProcessor.ts
@@ -8,7 +8,7 @@ import { ISender, ITransactionBuilder, ITransactionProcessor } from "../transact
 
 @injectable()
 export class PaymentProcessor implements IPaymentProcessor {
-    
+
     private paymentBuilder : IPaymentBuilder
     private transactionBuilder : ITransactionBuilder
     private transactionProcessor : ITransactionProcessor
@@ -31,36 +31,36 @@ export class PaymentProcessor implements IPaymentProcessor {
 
     async run(args: any): Promise<void> {
         ConfigurationManager.build(args)
-        
-        const configuration = ConfigurationManager.Setup 
 
-        if (this.isValid(configuration)) {
-            
-            let paymentProcess = await this.paymentBuilder.build() 
-            
+        const configuration = ConfigurationManager.Setup
+
+        if (await this.isValid(configuration)) {
+
+            let paymentProcess = await this.paymentBuilder.build()
+
             await this.transactionBuilder.build(paymentProcess,configuration)
 
             await this.calculateTotalPayoutFundsNeeded(paymentProcess)
-            
-            await this.transactionProcessor.write(configuration, paymentProcess) 
+
+            await this.transactionProcessor.write(configuration, paymentProcess)
 
             await this.sender.send(configuration, paymentProcess)
 
             await this.summarizer.calculateTotals(paymentProcess)
 
             await this.summarizer.printTotals(paymentProcess)
-            
+
         } else {
             //TODO: Use a custom error class
             throw new Error ('Unkown Data Source')
         }
-        
+
     }
 
     private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess) {
         let totalPayoutFundsNeeded = 0
 
-        paymentProcess.payouts.map((t) => {totalPayoutFundsNeeded += t.amount + t.fee}); 
+        paymentProcess.payouts.map((t) => {totalPayoutFundsNeeded += t.amount + t.fee});
 
         paymentProcess.totalPayoutFundsNeeded = totalPayoutFundsNeeded
 
@@ -68,7 +68,7 @@ export class PaymentProcessor implements IPaymentProcessor {
     }
 
     private async isValid(config : PaymentConfiguration) : Promise<boolean> {
-        
+
         if (config.blockDataSource != "ARCHIVEDB" && config.blockDataSource != "MINAEXPLORER") {
             return false
         }
@@ -76,4 +76,3 @@ export class PaymentProcessor implements IPaymentProcessor {
         return true
         }
  }
-


### PR DESCRIPTION
Sorry about all the extra whitespace changes - line 37 is the only change - added await on isvalid. (I guess we could also change isvalid to not be async as another approach - it isn't doing anything but comparing vars.) Maybe that would be better? If you think that is better, please comment in review.

Unclear why some users get this error and others do not. Issue was reported by three separate pools:
https://discord.com/channels/484437221055922177/812415968101531708/881352968723648583
https://discord.com/channels/484437221055922177/799597981762453535/881626076890165348
https://discord.com/channels/484437221055922177/799597981762453535/881022813442543626

I could never reproduce, and neither could BeaconChain:
https://discord.com/channels/484437221055922177/799597981762453535/881782051320242217

I tested this branch successfully, as did other pools:
https://discord.com/channels/484437221055922177/812415968101531708/881824576047312966
https://discord.com/channels/484437221055922177/799597981762453535/881045624823349279
