### PR TITLE
Fix error "ERROR: Public Key is invalid at line N."

### DIFF
--- a/src/configuration/ConfigurationManager.ts
+++ b/src/configuration/ConfigurationManager.ts
@@ -85,7 +85,7 @@ const getComissionRates = async (): Promise<KeyCommissionRate> => {
 
         const raw = fs.readFileSync(path, 'utf-8');
 
-        const rows = raw.split(/\r?\n/);
+        const rows = raw.split(/\r?\n/).filter(row => row);
 
         rows.forEach((x, index) => {
             const [key, rate] = x.split('|');


### PR DESCRIPTION
Hello,

Here is a fix for the error "ERROR: Public Key is invalid at line N." that is encountered when using a ".negotiatedFees" file.
It just clean up .negotiatedFees empty rows.