### PR TITLE
Separate sign from send

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,10 @@ The process will also maintain a list of blocks for which it generated signed pa
 
 ## Handling failed transmissions
 
-Sometimes a transaction be successfully sent to the node, but then fail to actually send in the network. That causes all subsequent payments to fail because the nonce is then incorrect.
+Sometimes a transaction be successfully sent to the node, but then fail to actually send in the network. As of 5/11/2022, the application will continue to generate, sign, and store .gql files for each transaction; however, it will no longer attempt to send transactions to the network after encountering a failure. Instead, the trasnactions not sent can be resent using the resend command.
 
-All attempted payouts are automatically logged in the src/data directory - and now those files can be used to automatically resend failures after a given nonce. There is a new command: `npm run resend -- -f=[nonce]` which will scan the src/data directory for files named .gql, and attempt to resent all files that have a nonce (based on the file name) *equal to* or greater than the supplied parameter.
+`npm run resend -- -fromNone=[nonce] -toNonce=[nonce]`
 
-So `npm run resend -- -f=3102` will try to re-transmit any files it finds named 3102.gql or higher - e.g. 3102.gql, 3103.gql, 3014.gql will all be tretransmitted. There is no upper boundary since any failure should cause all subsequent transactions to fail, so all should be re-transmitted. This command uses the graphql endpoint specified in the .env file.
+All attempted payouts are automatically logged in the src/data directory. The resend command will scan the src/data directory for files named .gql, and attempt to resend all files that have a nonce (based on the file name) *equal to* or between the supplied parameters. (The from/to parameters can be shortened: `-fromNonce` alias -f; `-toNonce` alias -t.)
+
+For example, `npm run resend -- -f=3102 -t=3104` will try to re-transmit any files it finds named 3102.gql up to 3104.gql. This command uses the graphql endpoint specified in the .env file.

--- a/src/resender.ts
+++ b/src/resender.ts
@@ -1,5 +1,8 @@
 import { resendSignedPaymentFromFile } from './utils/resend-payment';
 import yargs from 'yargs';
-const args = yargs.options('fromNonce', { type: 'number', alias: ['f'] }).argv;
+const args = yargs.options({
+    fromNonce: { type: 'number', alias: ['f'] },
+    toNonce: { type: 'number', alias: ['t'] }
+}).argv;
 console.log('*** RESENDING TRANSACTIONS ***\n');
 resendSignedPaymentFromFile(args);

--- a/src/utils/resend-payment.ts
+++ b/src/utils/resend-payment.ts
@@ -1,16 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { gql } from '@apollo/client/core';
 import fs from 'fs';
-import path, { resolve } from 'path';
+import path from 'path';
 import { sendPaymentGraphQL } from '../infrastructure/graphql-pay';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function resendSignedPaymentFromFile(args: any): Promise<void> {
     const dir = path.join(__dirname, '/../data/');
     const fromNonce = args.fromNonce;
+    const toNonce = args.toNonce;
     const fileList = fs.readdirSync(dir).filter((f) => {
         if (f.substring(f.indexOf('.')) === '.gql') {
-            if (Number(f.substring(0, f.indexOf('.'))) >= Number(fromNonce)) {
+            if (
+                Number(f.substring(0, f.indexOf('.'))) >= Number(fromNonce) &&
+                Number(f.substring(0, f.indexOf('.'))) <= Number(toNonce)
+            ) {
                 return true;
             } else {
                 return false;

--- a/src/utils/send-payments.ts
+++ b/src/utils/send-payments.ts
@@ -69,7 +69,7 @@ export async function sendSignedTransactions(
 ): Promise<any> {
     let nonce = await getNonce(keys.publicKey);
     let continueSending = true;
-  let timeout = 5000;
+    let timeout = 5000;
     payoutsToSign.reduce(async (previousPromise, payout) => {
         await previousPromise;
         return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Separating sign transactions vs. send transactions to deal with intermittent node failures.

If an error occurs sending transactions, payout will stop trying to send and instead rapidly generate, sign, and store all remaining transactions for the run. Those transactions not sent can be re-transmitted manually using the resend command. (Details in readme.)