### PR TITLE
handling >120k staker*blocks array

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "start": "npm run payout -- -m=0",
         "test": "jest"
     },
-    "keywords": [ ],
+    "keywords": [],
     "author": "",
     "license": "ISC",
     "devDependencies": {

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -82,7 +82,9 @@ export class PaymentBuilder implements IPaymentBuilder {
 
                 payouts.push(...ledgerPayouts);
 
-                storePayout.push(...ledgerStorePayout);
+                for (let i = 0; i < ledgerStorePayout.length; i++) {
+                    storePayout.push(ledgerStorePayout[i]);
+                }
 
                 console.log(`We won these blocks: ${blocksIncluded}`);
 


### PR DESCRIPTION
Prior code was throwing RangeError: Maximum call stack size exceeded because the expansion of the array when putting the detailed list exceeds stack size. Test case was array of ~130k items. Changed to for loop to manually copy in array. 

Better treatment would be to re-use the already populated array, but I didn't dig into that to trace what the impacts may be for this hot fix. 

Tested with large pool - confirmed resolved.