### PR TITLE
fixup output messages to show mina to transfer helper text

### DIFF
--- a/src/core/payment/PaymentProcessor.ts
+++ b/src/core/payment/PaymentProcessor.ts
@@ -54,7 +54,7 @@ export class PaymentProcessor implements IPaymentProcessor {
         }
     }
 
-    private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess, config: PaymentConfiguration) {
+    private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess, configuration: PaymentConfiguration) {
         let totalPayoutFundsNeeded = 0;
 
         paymentProcess.payouts.map((t) => {
@@ -68,7 +68,7 @@ export class PaymentProcessor implements IPaymentProcessor {
         );
         console.log(
             `Fund via: mina_ledger_wallet send-payment --offline --network testnet --nonce FUNDERNONCE --fee 0.1 BIP44ACCOUNT FUNDING_FROM_ADDRESS ${
-                config.senderKeys.publicKey
+                configuration.senderKeys.publicKey
             } ${totalPayoutFundsNeeded / 1000000000}`,
         );
     }

--- a/src/core/payment/PaymentProcessor.ts
+++ b/src/core/payment/PaymentProcessor.ts
@@ -54,14 +54,23 @@ export class PaymentProcessor implements IPaymentProcessor {
         }
     }
 
-    private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess, configuration: PaymentConfiguration) {
+    private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess, config: PaymentConfiguration) {
         let totalPayoutFundsNeeded = 0;
 
         paymentProcess.payouts.map((t) => {
             totalPayoutFundsNeeded += t.amount + t.fee;
         });
 
-        console.log(`Total Funds Required for Payout = ${totalPayoutFundsNeeded}`);
+        console.log(
+            `Total Funds Required for Payout = ${totalPayoutFundsNeeded} nanoMINA or ${
+                totalPayoutFundsNeeded / 1000000000
+            } MINA`,
+        );
+        console.log(
+            `Fund via: mina_ledger_wallet send-payment --offline --network testnet --nonce FUNDERNONCE --fee 0.1 BIP44ACCOUNT FUNDING_FROM_ADDRESS ${
+                config.senderKeys.publicKey
+            } ${totalPayoutFundsNeeded / 1000000000}`,
+        );
     }
 
     private async isValid(config: PaymentConfiguration): Promise<boolean> {

--- a/src/core/transaction/TransactionProcessor.ts
+++ b/src/core/transaction/TransactionProcessor.ts
@@ -36,12 +36,6 @@ export class TransactionProcessor implements ITransactionProcessor {
         );
 
         this.fileWriter.write(payoutDetailsFileName, JSON.stringify(storePayout));
-
-        console.log(
-            `Fund via: mina_ledger_wallet send-payment --offline --network testnet --nonce FUNDERNONCE --fee 0.1 BIP44ACCOUNT FUNDING_FROM_ADDRESS ${
-                config.senderKeys.publicKey
-            } ${totalPayoutFundsNeeded / 1000000000}`,
-        );
     }
 
     private generateOutputFileName(


### PR DESCRIPTION
Restoring prior functionality.

Due to pr 104/107 restructuring, total funds needed for payout was not available to log message. 

Moved log message to where the details are calculated. Not the cleanest, but will prevent breaking / support queries at the end of the epoch.