### PR TITLE
support SPLIT in substitutePayTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ The file is pipe-delimited and contains 2 columns - the first column is the publ
 
 -   Public Key|EXCLUDE
 -   Public Key|Redirected To Public Key
+-   Public Key|SPLIT|Second public key|Fraction
 
-In the example content below, the first row would cause any payouts to the first key to not be sent. This may be useful for the pool operator's keys. The second row would cause any payouts to the key ending in WCvh to be sent instead to the key ending in Ez3yB. This is useful for redirecting new tokens that would be paid to a locked account to go to an unlocked account instead.
+In the example content below, the first row would cause any payouts to the first key to not be sent. This may be useful for the pool operator's keys. The second row would cause any payouts to the key ending in WCvh to be sent instead to the key ending in Ez3yB. This is useful for redirecting new tokens that would be paid to a locked account to go to an unlocked account instead. The third row would split the payout such that 0.4\*payout (40 percent of the payout) goes to the key ending in WCvh and the rest to the key ending in Ez3yB.
 
 ```
 B62qkBqSkXgkirtU3n8HJ9YgwHh3vUD6kGJ5ZRkQYGNPeL5xYL2tL1L|EXCLUDE
 B62qinpqDF7ongjhpvJLz7QBsExP1BkpceED6GuThYYbSVSbk1nWCvh|B62qoigHEtJCoZ5ekbGHWyr9hYfc6fkZ2A41h9vvVZuvty9amzEz3yB
+B62qinpqDF7ongjhpvJLz7QBsExP1BkpceED6GuThYYbSVSbk1nWCvh|SPLIT|B62qoigHEtJCoZ5ekbGHWyr9hYfc6fkZ2A41h9vvVZuvty9amzEz3yB|0.4
 ```
 
 To enable these features, create a file src/data/.substitutePayTo and configure it according to your situation.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@o1labs/client-sdk": "^1.0.0",
         "cross-fetch": "^3.1.5",
         "csv": "^6.2.0",
+        "csv-parse": "^5.5.3",
         "graphql": "^16.5.0",
         "help": "^3.0.2",
         "inversify": "^6.0.1",

--- a/src/core/payment/SubstituteAndExcludePayToAddresses.ts
+++ b/src/core/payment/SubstituteAndExcludePayToAddresses.ts
@@ -21,14 +21,38 @@ export class SubstituteAndExcludePayToAddresses implements ISubstituteAndExclude
         const filterPayouts = () => {
             return new Promise((resolve, reject) => {
                 fs.createReadStream(substitutePayToFile)
-                    .pipe(parse({ delimiter: '|' }))
+                    .pipe(parse({ delimiter: '|', relax_column_count: true }))
                     .on('data', (record) => {
                         transactions = transactions
                             .filter((transaction) => !(transaction.publicKey == record[0] && record[1] == 'EXCLUDE'))
                             .map((t) => {
-                                if (t.publicKey == record[0]) t.publicKey = record[1];
+				if (t.publicKey == record[0] && record[1] != 'SPLIT') t.publicKey = record[1];
                                 return t;
                             });
+			transactions = transactions.flatMap((t) => {
+                            if (t.publicKey == record[0] && record[1] == 'SPLIT') {
+                                const otherKey = record[2];
+                                const splitPercent = parseFloat(record[3]);
+                                const publicKeyAmount = Math.ceil(splitPercent * t.amount);
+                                const publicKeyAmountMina = publicKeyAmount / 1000000000;
+                                const otherKeyAmount = t.amount - publicKeyAmount;
+                                const otherKeyAmountMina = otherKeyAmount / 1000000000;
+                                t.amount = publicKeyAmount;
+                                t.amountMina = publicKeyAmountMina;
+                                const otherKeyTransaction: PayoutTransaction = {
+                                    publicKey: otherKey,
+                                    amount: otherKeyAmount,
+                                    fee: t.fee,
+                                    amountMina: otherKeyAmountMina,
+                                    feeMina: t.feeMina,
+                                    memo: t.memo,
+                                };
+
+                                return [t, otherKeyTransaction];
+                            } else {
+                                return [t];
+                            }
+                        });
                     })
                     .on('end', resolve)
                     .on('error', reject);

--- a/src/core/payment/SubstituteAndExcludePayToAddressesForSuperCharge.ts
+++ b/src/core/payment/SubstituteAndExcludePayToAddressesForSuperCharge.ts
@@ -25,7 +25,7 @@ export class SubstituteAndExcludePayToAddressesForSuperCharge implements ISubsti
         const filterPayouts = (filterFile: any) => {
             return new Promise((resolve, reject) => {
                 fs.createReadStream(filterFile)
-                    .pipe(parse({ delimiter: '|' }))
+                    .pipe(parse({ delimiter: '|', relax_column_count: true }))
                     .on('data', (record) => {
                         transactions = transactions
                             .filter(

--- a/src/core/transaction/TransactionBuilder.ts
+++ b/src/core/transaction/TransactionBuilder.ts
@@ -62,7 +62,7 @@ export class TransactionBuilder implements ITransactionBuilder {
 
         console.table(transactions);
 
-        paymentProcess.payoutsBeforeExclusions = transactions;
+	paymentProcess.payoutsBeforeExclusions = JSON.parse(JSON.stringify(transactions));
 
         transactions = await this.substituteAndExcludePayToAddresses.run(transactions);
 


### PR DESCRIPTION
Also, add csv-parse which seems to be missing from the dependencies.

We also reserialize the list of transactions since the SPLIT directive changes the objects in place and would cause havoc otherwise.