### PR TITLE
add support for .burnSupercharged list; add to NPS and burn extra coinbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Before to send any payout please make sure:
 -   Make sure the total coinbase amount is valid and aligned with the details displayed during the execution of the script.
 -   You can see more details by enabling the debug mode. This can be achieved by adding --verbose=true to the command line.
 
-## Example 1: 
+## Example 1:
 ![Alt Verification steps](./src/img/dry-run-supercharged.png?raw=true)
 
-## Example 2:  
+## Example 2:
 ![Alt Verification steps](./src/img/dry-run-no-supercharged.png?raw=true)
 
 # mina-pool-payout
@@ -188,6 +188,10 @@ B62qinpqDF7ongjhpvJLz7QBsExP1BkpceED6GuThYYbSVSbk1nWCvh|0.012544
 ```
 
 If no file is present, the process will use the default `COMMISSION_RATE` value
+
+## Adding accounts as Non-Paticipating and burning their supercharged coinbase
+
+You can add accounts as non-participating and burn their supercharged coinbase. This is configured with a file named ".burnSupercharged" which should be placed in the src/data directory. Simply place the public key address in the .burnSupercharged file and the process will treat that key similar to Investor and MF keys and will burn any supercharged coinbase they create, and will put the account in the non-participating payout pool (they will never earn a part of supercharged coinbases.) If you use the standard payout (not isolate supercharged) then they may still be weighted if unlocked, but by default will not receive any supercharged coinbase unless you have changed the code to run the original payout calculator.
 
 ## Running payout for a full epoch
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^28.1.3",
-        "nodemon": "^2.0.19",
+        "nodemon": "^3.0.2",
         "prettier": "^2.7.1",
         "reflect-metadata": "^0.1.13",
         "ts-jest": "^28.0.7",

--- a/sample.env
+++ b/sample.env
@@ -27,11 +27,8 @@ NUM_SLOTS_IN_EPOCH=7140
 MIN_CONFIRMATIONS=50
 
 # Archive database uri
-# piconbellow is providing a public endpoint here: _do your own research_
 #DATABASE_URL=### provide database URL ###
 
 # GraphQL Endpoints
-# beaconchain is providing a public endpoint here: _do your own research_
 #SEND_PAYMENT_GRAPHQL_ENDPOINT=http://mynodeip:3085/graphql
-SEND_PAYMENT_GRAPHQL_ENDPOINT=https://minagraph.com/graphql
 MINAEXPLORER_GRAPHQL_ENDPOINT=https://graphql.minaexplorer.com

--- a/sample.env
+++ b/sample.env
@@ -30,5 +30,5 @@ MIN_CONFIRMATIONS=50
 #DATABASE_URL=### provide database URL ###
 
 # GraphQL Endpoints
-#SEND_PAYMENT_GRAPHQL_ENDPOINT=http://mynodeip:3085/graphql
+SEND_PAYMENT_GRAPHQL_ENDPOINT=http://mynodeip:3085/graphql
 MINAEXPLORER_GRAPHQL_ENDPOINT=https://graphql.minaexplorer.com

--- a/src/core/payoutCalculator/PayoutCalculator.ts
+++ b/src/core/payoutCalculator/PayoutCalculator.ts
@@ -40,7 +40,9 @@ export class PayoutCalculator implements IPayoutCalculator {
                 const winnerStakeIsLocked = stakeIsLocked(winner, block);
                 const burnSuperChargedRewards =
                     block.coinbase == SUPERCHARGEDCOINBASE &&
-                    (winner.shareClass.shareOwner == 'MF' || winner.shareClass.shareOwner == 'INVEST');
+                    (winner.shareClass.shareOwner == 'MF' ||
+                        winner.shareClass.shareOwner == 'INVEST' ||
+                        winner.shareClass.shareOwner == 'BURN');
                 let sumEffectiveCommonPoolStakes = 0;
                 let sumEffectiveNPSPoolStakes = 0;
                 const effectivePoolStakes: {
@@ -120,9 +122,13 @@ export class PayoutCalculator implements IPayoutCalculator {
                             blockTotal = Math.floor(
                                 (1 - investorsCommissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting,
                             );
+                        } else if (staker.shareClass.shareOwner == 'BURN') {
+                            blockTotal = Math.floor(
+                                (1 - commissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting,
+                            );
                         } else {
                             throw new Error(
-                                'NPS shares should be MF or O1 or INVEST. Found NPS Shares with other owner.',
+                                'NPS shares should be MF or O1 or INVEST or BURN. Found NPS Shares with other owner.',
                             );
                         }
                     } else {

--- a/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
@@ -41,7 +41,9 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                 const winnerStakeIsLocked = stakeIsLocked(winner, block);
                 const burnSuperChargedRewards =
                     block.coinbase == SUPERCHARGEDCOINBASE &&
-                    (winner.shareClass.shareOwner == 'MF' || winner.shareClass.shareOwner == 'INVEST');
+                    (winner.shareClass.shareOwner == 'MF' ||
+                        winner.shareClass.shareOwner == 'INVEST' ||
+                        winner.shareClass.shareOwner == 'BURN');
                 let sumEffectiveCommonPoolStakes = 0;
                 let sumEffectiveNPSPoolStakes = 0;
                 let sumEffectiveSuperchargedPoolStakes = 0;
@@ -136,9 +138,13 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                             blockTotal = Math.floor(
                                 (1 - investorsCommissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting,
                             );
+                        } else if (staker.shareClass.shareOwner == 'BURN') {
+                            blockTotal = Math.floor(
+                                (1 - commissionRate) * totalNPSPoolRewards * effectiveNPSPoolWeighting,
+                            );
                         } else {
                             throw new Error(
-                                'NPS shares should be MF or O1 or INVEST. Found NPS Shares with other owner.',
+                                'NPS shares should be MF or O1 or INVEST or BURN. Found NPS Shares with other owner.',
                             );
                         }
                     } else {

--- a/src/utils/staking-ledger-util.ts
+++ b/src/utils/staking-ledger-util.ts
@@ -10,9 +10,14 @@ export function getPublicKeyShareClass(key: string): ShareClass {
     const foundationAddressesFile = path.join('src', 'data', 'nps-addresses', 'Mina_Foundation_Addresses.csv');
     const labsAddressesFile = path.join('src', 'data', 'nps-addresses', 'O1_Labs_Addresses.csv');
     const investorsAddressesFile = path.join('src', 'data', 'nps-addresses', 'Investors_Addresses.csv');
+    const burnAddressesFile = path.join('src', 'data', '.burnSupercharged');
     const foundationAddresses = fs.readFileSync(foundationAddressesFile);
     const o1labsAddresses = fs.readFileSync(labsAddressesFile);
     const investorsAddresses = fs.readFileSync(investorsAddressesFile);
+    let burnAddresses: Buffer = Buffer.from('');
+    if (fs.existsSync(burnAddressesFile)) {
+        burnAddresses = fs.readFileSync(burnAddressesFile);
+    }
 
     if (foundationAddresses.includes(key)) {
         return { shareClass: 'NPS', shareOwner: 'MF' };
@@ -20,6 +25,8 @@ export function getPublicKeyShareClass(key: string): ShareClass {
         return { shareClass: 'NPS', shareOwner: 'O1' };
     } else if (investorsAddresses.includes(key)) {
         return { shareClass: 'NPS', shareOwner: 'INVEST' };
+    } else if (burnAddresses.includes(key)) {
+        return { shareClass: 'NPS', shareOwner: 'BURN' };
     } else return { shareClass: 'Common', shareOwner: '' };
 }
 


### PR DESCRIPTION
Requested feature to allow pools to add more addresses to be treated as non-participating and burn their supercharged rewards.

Pools may have delegates whose tokens are locked by contract (not on-chain) who they need to exclude from supercharged rewards, and who would prefer to burn the supercharged portion of their coinbase in advance of the hard fork.

Added support for a new control file src/data/.burnSupercharged 

Any public keys found in the file will be treated as non-participating, and any supercharged portion of coinbase they generate will be burned.

The file does not need to be created if you don't have this scenario, and it is not in source control.