### PR TITLE
Implement variable rate burn for specific keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ B62qinpqDF7ongjhpvJLz7QBsExP1BkpceED6GuThYYbSVSbk1nWCvh|0.012544
 
 If no file is present, the process will use the default `COMMISSION_RATE` value
 
+## Burning a fraction of rewards
+
+Some delegates may request that a pool burn a portion of their rewards. The payout will burn a specific percentage of the rewards that would have been paid out ot a delegate if specified. To use this feature, create a file named .negotiatedBurn in the src/data directory. The file should contain rows in the format: "puyblic key|burn percentage". The burn percentage shoudl be expressed as a number. For example, the following configuration would would burn 5.05% of the payout to the specific key.
+
+```
+B62qkBqSkXgkirtU3n8HJ9YgwHh3vUD6kGJ5ZRkQYGNPeL5xYL2tL1L|0.0505
+```
+
 ## Adding accounts as Non-Paticipating and burning their supercharged coinbase
 
 You can add accounts as non-participating and burn their supercharged coinbase. This is configured with a file named ".burnSupercharged" which should be placed in the src/data directory. Simply place the public key address in the .burnSupercharged file and the process will treat that key similar to Investor and MF keys and will burn any supercharged coinbase they create, and will put the account in the non-participating payout pool (they will never earn a part of supercharged coinbases.) If you use the standard payout (not isolate supercharged) then they may still be weighted if unlocked, but by default will not receive any supercharged coinbase unless you have changed the code to run the original payout calculator.

--- a/src/configuration/ConfigurationManager.ts
+++ b/src/configuration/ConfigurationManager.ts
@@ -1,9 +1,9 @@
-import { PaymentConfiguration, KeyCommissionRate } from './Model';
+import { PaymentConfiguration, KeyedRate } from './Model';
 import fs from 'fs';
 import Container from '../composition/inversify.config';
 import { IBlockDataProvider, IDataProviderFactory } from '../core/dataProvider/Models';
 import TYPES from '../composition/Types';
-import { createHash } from 'node:crypto'
+import { createHash } from 'node:crypto';
 
 export class ConfigurationManager {
     public static Setup: PaymentConfiguration;
@@ -16,6 +16,7 @@ export class ConfigurationManager {
             epoch: args.epoch ?? Number(args.epoch),
             slotsInEpoch: Number(process.env.NUM_SLOTS_IN_EPOCH),
             commissionRatesByPublicKey: await getComissionRates(),
+            burnRatesByPublicKey: await getBurnRates(),
             stakingPoolPublicKey: process.env.POOL_PUBLIC_KEY || '',
             payoutMemo: process.env.POOL_MEMO || 'mina-pool-payout',
             bpKeyMd5Hash: getMemoMd5Hash(process.env.POOL_PUBLIC_KEY || ''),
@@ -59,8 +60,6 @@ export class ConfigurationManager {
         );
     }
 
-    
-
     private static async validate() {
         if (Number.isNaN(this.Setup.defaultCommissionRate)) {
             console.log('ERROR: Comission Rate is not a number - please set COMMISSION_RATE in .env file');
@@ -91,40 +90,46 @@ export class ConfigurationManager {
     }
 }
 
-const getComissionRates = async (): Promise<KeyCommissionRate> => {
+const getComissionRates = async (): Promise<KeyedRate> => {
     const path = `${__dirname}/../data/.negotiatedFees`;
+    const arbitraryMaxRate = 0.5;
+    return getKeyedRates(path, arbitraryMaxRate);
+};
 
-    if (fs.existsSync(path)) {
-        const commissionRates: KeyCommissionRate = {};
+const getBurnRates = async (): Promise<KeyedRate> => {
+    const path = `${__dirname}/../data/.negotiatedBurn`;
+    const arbitraryMaxRate = 1.0;
+    return getKeyedRates(path, arbitraryMaxRate);
+};
 
-        console.log('Found .negotiatedFees file. Using Payor Specific Commission Rates.');
+const getKeyedRates = async (configurationPath: string, maxRate: number): Promise<KeyedRate> => {
+    const keyedList: KeyedRate = {};
+    if (fs.existsSync(configurationPath)) {
+        console.log(`Found ${configurationPath} file. Using Specific Rates.`);
 
-        const raw = fs.readFileSync(path, 'utf-8');
+        const raw = fs.readFileSync(configurationPath, 'utf-8');
 
-        const rows = raw.split(/\r?\n/).filter(row => row);
+        const rows = raw.split(/\r?\n/).filter((row) => row);
 
         rows.forEach((x, index) => {
             const [key, rate] = x.split('|');
 
-            const takeRate = Number.parseFloat(rate);
+            const parsedRate = Number.parseFloat(rate);
 
-            const result = validateCommission(key, takeRate, index);
+            const result = validateRate(key, parsedRate, index, maxRate);
 
             if (!result.isValid) {
                 console.log(result.error);
                 throw new Error(result.error);
             }
 
-            commissionRates[key] = { commissionRate: takeRate };
+            keyedList[key] = { rate: parsedRate };
         });
-
-        return commissionRates;
     }
-
-    return {};
+    return keyedList;
 };
 
-const validateCommission = (key: string, rate: number, index: number) => {
+const validateRate = (key: string, rate: number, index: number, maxRate: number) => {
     const line = index + 1;
 
     const result = { error: '', isValid: false };
@@ -134,13 +139,13 @@ const validateCommission = (key: string, rate: number, index: number) => {
     }
 
     if (isNaN(rate)) {
-        return { ...result, error: `ERROR: Negotiated Fee is not a number. Key: ${key} at line ${line}.` };
+        return { ...result, error: `ERROR: Negotiated Rate is not a number. Key: ${key} at line ${line}.` };
     }
 
-    if (rate < 0.0 || rate > 0.5) {
+    if (rate < 0.0 || rate > maxRate) {
         return {
             ...result,
-            error: `ERROR: Negotiated Fees is outside of acceptable ranges 0.0-0.5. Key: ${key} at line ${line}.`,
+            error: `ERROR: Negotiated Rate is outside of acceptable ranges 0.0-${maxRate}. Key: ${key} at line ${line}.`,
         };
     }
 
@@ -153,4 +158,4 @@ const getMemoMd5Hash = (memo: string) => {
     } else { 
         return createHash('md5').update(memo).digest('hex');
     }
-}
+};

--- a/src/configuration/Model.ts
+++ b/src/configuration/Model.ts
@@ -2,27 +2,28 @@ import { keypair } from '@o1labs/client-sdk';
 
 export interface PaymentConfiguration {
     blockDataSource: string;
-    commissionRatesByPublicKey: KeyCommissionRate;
+    bpKeyMd5Hash: string;
+    burnAddress: string;
+    burnRatesByPublicKey: KeyedRate;
+    commissionRatesByPublicKey: KeyedRate;
     configuredMaximum: number;
     defaultCommissionRate: number;
-    mfCommissionRate: number;
-    o1CommissionRate: number;
-    investorsCommissionRate: number;
     epoch: number;
+    investorsCommissionRate: number;
+    mfCommissionRate: number;
     minimumConfirmations: number;
     minimumHeight: number;
+    o1CommissionRate: number;
     payoutHash: string;
     payoutMemo: string;
-    bpKeyMd5Hash: string;
     payorSendTransactionFee: number;
     payoutThreshold: number;
     senderKeys: keypair;
     slotsInEpoch: number;
     stakingPoolPublicKey: string;
     verbose: boolean;
-    burnAddress: string;
 }
 
-export interface KeyCommissionRate {
-    [publicKey: string]: { commissionRate: number};
+export interface KeyedRate {
+    [publicKey: string]: { rate: number };
 }

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -43,6 +43,7 @@ export class PaymentBuilder implements IPaymentBuilder {
             o1CommissionRate,
             investorsCommissionRate,
             commissionRatesByPublicKey,
+            burnRatesByPublicKey,
         } = config;
 
         const latestHeight = await blockProvider.getLatestHeight();
@@ -62,8 +63,8 @@ export class PaymentBuilder implements IPaymentBuilder {
 
         const storePayout: PayoutDetails[] = [];
 
-        let globalTotalPayout: number = 0;
-        let globalTotalToBurn: number = 0;
+        let globalTotalPayout = 0;
+        let globalTotalToBurn = 0;
 
         const ledgerHashes = [...new Set(blocks.map((block) => block.stakingledgerhash))];
 
@@ -87,6 +88,7 @@ export class PaymentBuilder implements IPaymentBuilder {
                         o1CommissionRate,
                         investorsCommissionRate,
                         commissionRatesByPublicKey,
+                        burnRatesByPublicKey,
                         config.burnAddress,
                         config.bpKeyMd5Hash,
                         config.payoutMemo,

--- a/src/core/payoutCalculator/Model.ts
+++ b/src/core/payoutCalculator/Model.ts
@@ -1,4 +1,4 @@
-import { KeyCommissionRate } from '../../configuration/Model';
+import { KeyedRate } from '../../configuration/Model';
 import { Block, Stake, ShareClass } from '../dataProvider/dataprovider-types';
 import { IFeeCalculator } from '../transaction/Model';
 
@@ -51,7 +51,8 @@ export interface IPayoutCalculator {
         mfCommissionRate: number,
         o1CommissionRate: number,
         investorsCommissionRate: number,
-        comissionRates: KeyCommissionRate,
+        comissionRates: KeyedRate,
+        burnRates: KeyedRate,
         burnAddress: string,
         bpKeyMd5Hash: string,
         configuredMemo: string,


### PR DESCRIPTION
Implements an anonymous community request to burn a fractional amount of rewards that would otherwise be distributed for a key. Some pools have custom agreements to burn some of the award for certain delegates.

Supports a new control file - .negotiatedBurn, which may exist and should contain the public key and the burn percentage - one key per row.