### PR TITLE
Changes to .negotiatedBurn handling to always apply 

### DIFF
--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -114,7 +114,9 @@ export class PaymentBuilder implements IPaymentBuilder {
 
                 console.log(`The Total Payout is: ${totalPayout} nm or ${totalPayout / 1000000000} mina`);
 
-                console.log(`The Total amount to burn is: ${globalTotalToBurn} nm or ${globalTotalToBurn / 1000000000} mina`);
+                console.log(
+                    `The Total amount to burn is: ${globalTotalToBurn} nm or ${globalTotalToBurn / 1000000000} mina`,
+                );
             }),
         ).then(async () => {
             // added a sort because these payout details are hashed and need to be in a reliable order
@@ -136,7 +138,7 @@ export class PaymentBuilder implements IPaymentBuilder {
                 totalPayoutFundsNeeded: 0,
                 payoutsBeforeExclusions: [],
                 totalPayouts: globalTotalPayout,
-                totalBurn: globalTotalToBurn
+                totalBurn: globalTotalToBurn,
             };
 
             return paymentProcess;

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -78,26 +78,33 @@ export class PaymentBuilder implements IPaymentBuilder {
 
                 const ledgerBlocks = blocks.filter((x) => x.stakingledgerhash == ledgerHash);
 
-                const [ledgerPayouts, ledgerStorePayout, blocksIncluded, totalPayout, totalToBurn] =
-                    await this.payoutCalculator.getPayouts(
-                        ledgerBlocks,
-                        stakers,
-                        totalStake,
-                        defaultCommissionRate,
-                        mfCommissionRate,
-                        o1CommissionRate,
-                        investorsCommissionRate,
-                        commissionRatesByPublicKey,
-                        burnRatesByPublicKey,
-                        config.burnAddress,
-                        config.bpKeyMd5Hash,
-                        config.payoutMemo,
-                    );
+                const [
+                    ledgerPayouts,
+                    ledgerStorePayout,
+                    blocksIncluded,
+                    totalPayout,
+                    totalSuperchargedToBurn,
+                    totalNegotiatedBurn,
+                ] = await this.payoutCalculator.getPayouts(
+                    ledgerBlocks,
+                    stakers,
+                    totalStake,
+                    defaultCommissionRate,
+                    mfCommissionRate,
+                    o1CommissionRate,
+                    investorsCommissionRate,
+                    commissionRatesByPublicKey,
+                    burnRatesByPublicKey,
+                    config.burnAddress,
+                    config.bpKeyMd5Hash,
+                    config.payoutMemo,
+                );
 
                 payouts.push(...ledgerPayouts);
 
                 globalTotalPayout = totalPayout;
-                globalTotalToBurn = totalToBurn;
+                globalTotalToBurn = totalSuperchargedToBurn + totalNegotiatedBurn;
+                //ADD TOTAL TO NEGOTIATED BURN
 
                 for (let i = 0; i < ledgerStorePayout.length; i++) {
                     storePayout.push(ledgerStorePayout[i]);
@@ -107,7 +114,7 @@ export class PaymentBuilder implements IPaymentBuilder {
 
                 console.log(`The Total Payout is: ${totalPayout} nm or ${totalPayout / 1000000000} mina`);
 
-                console.log(`The Total amount to burn is: ${totalToBurn} nm or ${totalToBurn / 1000000000} mina`);
+                console.log(`The Total amount to burn is: ${globalTotalToBurn} nm or ${globalTotalToBurn / 1000000000} mina`);
             }),
         ).then(async () => {
             // added a sort because these payout details are hashed and need to be in a reliable order

--- a/src/core/payment/SubstituteAndExcludePayToAddressesForSuperCharge.ts
+++ b/src/core/payment/SubstituteAndExcludePayToAddressesForSuperCharge.ts
@@ -34,10 +34,10 @@ export class SubstituteAndExcludePayToAddressesForSuperCharge implements ISubsti
                                     !(transaction.amount <= payoutThreshold),
                             )
                             .map((t) => {
-				if (t.publicKey == record[0] && record[1] != 'SPLIT') t.publicKey = record[1];
+                                if (t.publicKey == record[0] && record[1] != 'SPLIT') t.publicKey = record[1];
                                 return t;
                             });
-			transactions = transactions.flatMap((t) => {
+                        transactions = transactions.flatMap((t) => {
                             if (t.publicKey == record[0] && record[1] == 'SPLIT') {
                                 const otherKey = record[2];
                                 const splitPercent = parseFloat(record[3]);
@@ -54,6 +54,7 @@ export class SubstituteAndExcludePayToAddressesForSuperCharge implements ISubsti
                                     amountMina: otherKeyAmountMina,
                                     feeMina: t.feeMina,
                                     memo: t.memo,
+                                    summaryGroup: 0,
                                 };
 
                                 return [t, otherKeyTransaction];
@@ -66,7 +67,7 @@ export class SubstituteAndExcludePayToAddressesForSuperCharge implements ISubsti
                     .on('error', reject);
             });
         };
-        
+
         if (fs.existsSync(mfSubstitutePayToFile)) {
             await filterPayouts(mfSubstitutePayToFile);
         }
@@ -74,7 +75,7 @@ export class SubstituteAndExcludePayToAddressesForSuperCharge implements ISubsti
         if (fs.existsSync(substitutePayToFile)) {
             await filterPayouts(substitutePayToFile);
         }
-        
+
         return transactions;
     }
 }

--- a/src/core/payoutCalculator/Model.ts
+++ b/src/core/payoutCalculator/Model.ts
@@ -57,7 +57,14 @@ export interface IPayoutCalculator {
         bpKeyMd5Hash: string,
         configuredMemo: string,
     ): Promise<
-        [payoutJson: PayoutTransaction[], storePayout: PayoutDetails[], blocksIncluded: number[], totalPayout: number, totalToBurn: number]
+        [
+            payoutJson: PayoutTransaction[],
+            storePayout: PayoutDetails[],
+            blocksIncluded: number[],
+            totalPayout: number,
+            totalSuperchargedToBurn: number,
+            totalNegotiatedBurn: number,
+        ]
     >;
 }
 

--- a/src/core/payoutCalculator/Model.ts
+++ b/src/core/payoutCalculator/Model.ts
@@ -40,6 +40,7 @@ export type PayoutTransaction = {
     amountMina: number;
     feeMina: number;
     memo: string;
+    summaryGroup: number;
 };
 
 export interface IPayoutCalculator {

--- a/src/core/payoutCalculator/PayoutCalculator.ts
+++ b/src/core/payoutCalculator/PayoutCalculator.ts
@@ -63,7 +63,7 @@ export class PayoutCalculator implements IPayoutCalculator {
                 const totalNPSPoolRewards = winnerStakeIsLocked ? block.coinbase : REGULARCOINBASE;
                 // 20231201 implement new MF rules to burn supercharged rewards
                 const burnSuperchargedAmount = burnSuperChargedRewards ? REGULARCOINBASE : 0;
-                const totalCommonPoolRewards = totalRewards - totalNPSPoolRewards - burnAmount;
+                const totalCommonPoolRewards = totalRewards - totalNPSPoolRewards - burnSuperchargedAmount;
                 totalSuperchargedToBurn += burnSuperchargedAmount;
 
                 // Determine the supercharged discount for the block

--- a/src/core/payoutCalculator/PayoutCalculator.ts
+++ b/src/core/payoutCalculator/PayoutCalculator.ts
@@ -25,7 +25,8 @@ export class PayoutCalculator implements IPayoutCalculator {
             storePayout: PayoutDetails[],
             blocksIncluded: number[],
             totalPayout: number,
-            totalToBurn: number,
+            totalSuperchargedToBurn: number,
+            totalNegotiatedBurn: number,
         ]
     > {
         // Initialize some stuff
@@ -33,7 +34,8 @@ export class PayoutCalculator implements IPayoutCalculator {
         const REGULARCOINBASE = 720000000000;
         const blocksIncluded: number[] = [];
         const storePayout: PayoutDetails[] = [];
-        let totalToBurn = 0;
+        let totalSuperchargedToBurn = 0;
+        let totalNegotiatedBurn = 0;
 
         // for each block, calculate the effective stake of each staker
         blocks.forEach((block: Block) => {
@@ -60,9 +62,9 @@ export class PayoutCalculator implements IPayoutCalculator {
                 const totalRewards = block.coinbase + block.feetransfertoreceiver - block.feetransferfromcoinbase;
                 const totalNPSPoolRewards = winnerStakeIsLocked ? block.coinbase : REGULARCOINBASE;
                 // 20231201 implement new MF rules to burn supercharged rewards
-                const burnAmount = burnSuperChargedRewards ? REGULARCOINBASE : 0;
+                const burnSuperchargedAmount = burnSuperChargedRewards ? REGULARCOINBASE : 0;
                 const totalCommonPoolRewards = totalRewards - totalNPSPoolRewards - burnAmount;
-                totalToBurn += burnAmount;
+                totalSuperchargedToBurn += burnSuperchargedAmount;
 
                 // Determine the supercharged discount for the block
                 //  unlocked accounts will get a double share less this discount based on the ratio of fees : coinbase
@@ -145,17 +147,10 @@ export class PayoutCalculator implements IPayoutCalculator {
                     }
 
                     // After calculating the block award, if the delegate has a fractional burn, move some of the blocktotal to the burn address
-                    const burnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
-                    if (burnAmount != 0 && burnRate > 0) {
-                        throw new Error(
-                            'Attempting to burn due to supercharged AND burning due to negotiated burn rate for the same key. Review configuration in .negotiatedBurn. Key should not be part of supercharged burn configuration and variable rate burn configuration at the same time.',
-                        );
-                    } else if (burnRate > 0) {
-                        const burnAmount = Math.floor(blockTotal * burnRate);
-                        blockTotal -= burnAmount;
-                        totalToBurn += burnAmount;
-                    }
-
+                    const negotiatedBurnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
+                    const negotiatedBurnAmount = Math.floor(blockTotal * negotiatedBurnRate);
+                    totalNegotiatedBurn += negotiatedBurnAmount;
+                    blockTotal -= negotiatedBurnAmount;
                     staker.total += blockTotal;
 
                     // Store this data in a structured format for later querying and for the payment script, handled seperately
@@ -190,7 +185,7 @@ export class PayoutCalculator implements IPayoutCalculator {
                         totalRewardsSuperchargedPool: 0,
                     });
                 });
-                if (burnAmount > 0) {
+                if (totalSuperchargedToBurn > 0) {
                     storePayout.push({
                         publicKey: burnAddress,
                         owner: 'BURN',
@@ -211,7 +206,39 @@ export class PayoutCalculator implements IPayoutCalculator {
                         dateTime: block.blockdatetime,
                         coinbase: 0,
                         totalRewards: 0,
-                        totalRewardsToBurn: burnAmount,
+                        totalRewardsToBurn: totalSuperchargedToBurn,
+                        totalRewardsNPSPool: 0,
+                        totalRewardsCommonPool: 0,
+                        payout: 0,
+                        isEffectiveSuperCharge: false,
+                        effectiveSuperchargedPoolWeighting: 0,
+                        effectiveSuperchargedPoolStakes: 0,
+                        sumEffectiveSuperchargedPoolStakes: 0,
+                        totalRewardsSuperchargedPool: 0,
+                    });
+                }
+                if (totalNegotiatedBurn > 0) {
+                    storePayout.push({
+                        publicKey: burnAddress,
+                        owner: 'BURN',
+                        blockHeight: block.blockheight,
+                        globalSlot: block.globalslotsincegenesis,
+                        publicKeyUntimedAfter: 0,
+                        winnerShareOwner: winner.shareClass.shareOwner,
+                        shareClass: { shareClass: 'BURN', shareOwner: 'BURN' },
+                        stateHash: block.statehash,
+                        stakingBalance: 0,
+                        effectiveNPSPoolWeighting: 0,
+                        effectiveNPSPoolStakes: 0,
+                        effectiveCommonPoolWeighting: 0,
+                        effectiveCommonPoolStakes: 0,
+                        sumEffectiveNPSPoolStakes: 0,
+                        sumEffectiveCommonPoolStakes: 0,
+                        superchargedWeightingDiscount: 0,
+                        dateTime: block.blockdatetime,
+                        coinbase: 0,
+                        totalRewards: 0,
+                        totalRewardsToBurn: totalNegotiatedBurn,
                         totalRewardsNPSPool: 0,
                         totalRewardsCommonPool: 0,
                         payout: 0,
@@ -240,23 +267,34 @@ export class PayoutCalculator implements IPayoutCalculator {
                         staker.shareClass.shareOwner === 'MF' || staker.shareClass.shareOwner === 'INVEST'
                             ? bpKeyMd5Hash
                             : configuredMemo,
+                    summaryGroup: 0,
                 });
                 totalPayout += amount;
             }
         });
-
-        if (totalToBurn > 0) {
+        if (totalSuperchargedToBurn > 0) {
             payoutJson.push({
                 publicKey: burnAddress,
-                amount: totalToBurn,
+                amount: totalSuperchargedToBurn,
                 fee: 0,
                 amountMina: 0,
                 feeMina: 0,
                 memo: bpKeyMd5Hash,
+                summaryGroup: 1,
             });
         }
-
-        return [payoutJson, storePayout, blocksIncluded, totalPayout, totalToBurn];
+        if (totalNegotiatedBurn > 0) {
+            payoutJson.push({
+                publicKey: burnAddress,
+                amount: totalNegotiatedBurn,
+                fee: 0,
+                amountMina: 0,
+                feeMina: 0,
+                memo: configuredMemo,
+                summaryGroup: 2,
+            });
+        }
+        return [payoutJson, storePayout, blocksIncluded, totalPayout, totalSuperchargedToBurn, totalNegotiatedBurn];
     }
 
     private getWinner(stakers: Stake[], block: Block): Stake {

--- a/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
@@ -284,6 +284,7 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                         staker.shareClass.shareOwner === 'MF' || staker.shareClass.shareOwner === 'INVEST'
                             ? bpKeyMd5Hash
                             : configuredMemo,
+                    summaryGroup: 0,
                 });
                 totalPayout += amount;
             }
@@ -296,6 +297,7 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                 amountMina: 0,
                 feeMina: 0,
                 memo: bpKeyMd5Hash,
+                summaryGroup: 1,
             });
         }
         if (totalNegotiatedBurn > 0) {
@@ -306,6 +308,7 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                 amountMina: 0,
                 feeMina: 0,
                 memo: configuredMemo,
+                summaryGroup: 2,
             });
         }
         return [payoutJson, storePayout, blocksIncluded, totalPayout, totalSuperchargedToBurn, totalNegotiatedBurn];

--- a/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorIsolateSuperCharge.ts
@@ -20,7 +20,14 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
         bpKeyMd5Hash: string,
         configuredMemo: string,
     ): Promise<
-        [payoutJson: PayoutTransaction[], storePayout: PayoutDetails[], blocksIncluded: number[], totalPayout: number, totalToBurn: number]
+        [
+            payoutJson: PayoutTransaction[],
+            storePayout: PayoutDetails[],
+            blocksIncluded: number[],
+            totalPayout: number,
+            totalSuperchargedToBurn: number,
+            totalNegotiatedBurn: number,
+        ]
     > {
         //TODO: JC - Shared Logic must be moved into its own class, then isolate change in behaviors
         // Initialize some stuff
@@ -28,7 +35,8 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
         const REGULARCOINBASE = 720000000000;
         const blocksIncluded: number[] = [];
         const storePayout: PayoutDetails[] = [];
-        let totalToBurn = 0;
+        let totalSuperchargedToBurn = 0;
+        let totalNegotiatedBurn = 0;
 
         // for each block, calculate the effective stake of each staker
         blocks.forEach((block: Block) => {
@@ -54,12 +62,13 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
 
                 const totalRewards = block.coinbase + block.feetransfertoreceiver - block.feetransferfromcoinbase;
                 const totalNPSPoolRewards = winnerStakeIsLocked ? block.coinbase : REGULARCOINBASE;
-                const burnAmount = burnSuperChargedRewards ? REGULARCOINBASE : 0;
+                const burnSuperchargedAmount = burnSuperChargedRewards ? REGULARCOINBASE : 0;
                 const totalSuperchargedPoolRewards =
                     winnerStakeIsLocked || burnSuperChargedRewards ? 0 : REGULARCOINBASE;
                 const totalCommonPoolRewards =
-                    totalRewards - totalNPSPoolRewards - burnAmount - totalSuperchargedPoolRewards;
-                totalToBurn += burnAmount;
+                    totalRewards - totalNPSPoolRewards - burnSuperchargedAmount - totalSuperchargedPoolRewards;
+                totalSuperchargedToBurn += burnSuperchargedAmount;
+
                 let totalUnweightedCommonStake = 0;
 
                 // Determine the non-participating and common pool weighting for each staker
@@ -155,17 +164,10 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                     }
 
                     // After calculating the block award, if the delegate has a fractional burn, move some of the blocktotal to the burn address
-                    const burnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
-                    if (burnAmount != 0 && burnRate > 0) {
-                        throw new Error(
-                            'Attempting to burn due to supercharged AND burning due to negotiated burn rate for the same key. Review configuration in .negotiatedBurn. Key should not be part of supercharged burn configuration and variable rate burn configuration at the same time.',
-                        );
-                    } else if (burnRate > 0) {
-                        const burnAmount = Math.floor(blockTotal * burnRate);
-                        blockTotal -= burnAmount;
-                        totalToBurn += burnAmount;
-                    }
-
+                    const negotiatedBurnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
+                    const negotiatedBurnAmount = Math.floor(blockTotal * negotiatedBurnRate);
+                    totalNegotiatedBurn += negotiatedBurnAmount;
+                    blockTotal -= negotiatedBurnAmount;
                     staker.total += blockTotal;
 
                     // Store this data in a structured format for later querying and for the payment script, handled seperately
@@ -200,7 +202,7 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                         isEffectiveSuperCharge: true,
                     });
                 });
-                if (burnAmount > 0) {
+                if (totalSuperchargedToBurn > 0) {
                     storePayout.push({
                         publicKey: burnAddress,
                         owner: 'BURN',
@@ -221,7 +223,39 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                         dateTime: block.blockdatetime,
                         coinbase: 0,
                         totalRewards: 0,
-                        totalRewardsToBurn: burnAmount,
+                        totalRewardsToBurn: totalSuperchargedToBurn,
+                        totalRewardsNPSPool: 0,
+                        totalRewardsCommonPool: 0,
+                        payout: 0,
+                        isEffectiveSuperCharge: false,
+                        effectiveSuperchargedPoolWeighting: 0,
+                        effectiveSuperchargedPoolStakes: 0,
+                        sumEffectiveSuperchargedPoolStakes: 0,
+                        totalRewardsSuperchargedPool: 0,
+                    });
+                }
+                if (totalNegotiatedBurn > 0) {
+                    storePayout.push({
+                        publicKey: burnAddress,
+                        owner: 'BURN',
+                        blockHeight: block.blockheight,
+                        globalSlot: block.globalslotsincegenesis,
+                        publicKeyUntimedAfter: 0,
+                        winnerShareOwner: winner.shareClass.shareOwner,
+                        shareClass: { shareClass: 'BURN', shareOwner: 'BURN' },
+                        stateHash: block.statehash,
+                        stakingBalance: 0,
+                        effectiveNPSPoolWeighting: 0,
+                        effectiveNPSPoolStakes: 0,
+                        effectiveCommonPoolWeighting: 0,
+                        effectiveCommonPoolStakes: 0,
+                        sumEffectiveNPSPoolStakes: 0,
+                        sumEffectiveCommonPoolStakes: 0,
+                        superchargedWeightingDiscount: 0,
+                        dateTime: block.blockdatetime,
+                        coinbase: 0,
+                        totalRewards: 0,
+                        totalRewardsToBurn: totalNegotiatedBurn,
                         totalRewardsNPSPool: 0,
                         totalRewardsCommonPool: 0,
                         payout: 0,
@@ -254,18 +288,27 @@ export class PayoutCalculatorIsolateSuperCharge implements IPayoutCalculator {
                 totalPayout += amount;
             }
         });
-        if (totalToBurn > 0) {
+        if (totalSuperchargedToBurn > 0) {
             payoutJson.push({
                 publicKey: burnAddress,
-                amount: totalToBurn,
+                amount: totalSuperchargedToBurn,
                 fee: 0,
                 amountMina: 0,
                 feeMina: 0,
                 memo: bpKeyMd5Hash,
             });
         }
-
-        return [payoutJson, storePayout, blocksIncluded, totalPayout, totalToBurn];
+        if (totalNegotiatedBurn > 0) {
+            payoutJson.push({
+                publicKey: burnAddress,
+                amount: totalNegotiatedBurn,
+                fee: 0,
+                amountMina: 0,
+                feeMina: 0,
+                memo: configuredMemo,
+            });
+        }
+        return [payoutJson, storePayout, blocksIncluded, totalPayout, totalSuperchargedToBurn, totalNegotiatedBurn];
     }
 
     private getWinner(stakers: Stake[], block: Block): Stake {

--- a/src/core/transaction/TransactionBuilder.ts
+++ b/src/core/transaction/TransactionBuilder.ts
@@ -20,8 +20,9 @@ export class TransactionBuilder implements ITransactionBuilder {
         let transactions: PayoutTransaction[] = [
             ...payouts
                 .reduce((r, o) => {
+                    const summaryGrouping = `${o.publicKey}:${o.summaryGroup}`;
                     const item: PayoutTransaction =
-                        r.get(o.publicKey) ||
+                        r.get(summaryGrouping) ||
                         Object.assign({}, o, {
                             amount: 0,
                             fee: 0,
@@ -35,14 +36,14 @@ export class TransactionBuilder implements ITransactionBuilder {
                     item.amountMina = item.amount / 1000000000;
                     item.feeMina = item.fee / 1000000000;
                     item.memo = o.memo;
-                    return r.set(o.publicKey, item);
+                    return r.set(summaryGrouping, item);
                 }, new Map())
                 .values(),
         ];
 
         if (config.verbose) {
             console.table(storePayout);
-                /*, [
+            /*, [
                 'publicKey',
                 'blockHeight',
                 'shareClass',
@@ -62,7 +63,7 @@ export class TransactionBuilder implements ITransactionBuilder {
 
         console.table(transactions);
 
-	paymentProcess.payoutsBeforeExclusions = JSON.parse(JSON.stringify(transactions));
+        paymentProcess.payoutsBeforeExclusions = JSON.parse(JSON.stringify(transactions));
 
         transactions = await this.substituteAndExcludePayToAddresses.run(transactions);
 


### PR DESCRIPTION
closes #126 

Adds ability to group payments to allow multiple payments to the same key (used to split MF burn transactions from .negotiatedBurn transactions.)

Will now always apply .negotiatedBurn

