### PR TITLE
make node version dependencies explicit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mina-payout",
   "version": "1.4.0",
   "description": "",
+  "engines": {
+    "node": ">=18.18.0"
+  },
   "main": "index.js",
   "scripts": {
     "build": "tsc -p .",


### PR DESCRIPTION
removing cross-fetch in favor of native fetch requires node versions >17.5; dev deps require 18.18.

Adding .npmrc and explicitly declaring node version dependency.