### PR TITLE
Sort results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 dist
 node_modules
-.env
+.env*
 /src/data/*
 !/src/data/nps-addresses/
 !/src/data/mfSubstitutePayTo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payout",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "engines": {
     "node": ">=18.18.0"

--- a/src/core/payment/Model.ts
+++ b/src/core/payment/Model.ts
@@ -7,9 +7,9 @@ export interface IPaymentProcessor {
 }
 
 export interface PaymentProcess {
-  payouts: PayoutTransaction[];
+  payoutTransactions: PayoutTransaction[];
   payoutsBeforeExclusions: PayoutTransaction[];
-  storePayout: PayoutDetails[];
+  payoutDetails: PayoutDetails[];
   maximumHeight: number;
   blocks: Block[];
   totalPayoutFundsNeeded: number;

--- a/src/core/payment/PaymentProcessor.ts
+++ b/src/core/payment/PaymentProcessor.ts
@@ -14,16 +14,16 @@ export class PaymentProcessor implements IPaymentProcessor {
   private summarizer: ISummarizer<PaymentProcess>;
 
   public constructor(
-        @inject(TYPES.IPaymentBuilder) paymentBuilder: IPaymentBuilder,
-        @inject(TYPES.ITransactionBuilder) transactionBuilder: ITransactionBuilder,
-        @inject(TYPES.ITransactionProcessor) transactionProcessor: ITransactionProcessor,
-        @inject(TYPES.ISender) sender: ISender,
-        @inject(TYPES.PaymentSummarizer) summarizer: ISummarizer<PaymentProcess>,
+    @inject(TYPES.IPaymentBuilder) paymentBuilder: IPaymentBuilder,
+    @inject(TYPES.ITransactionBuilder) transactionBuilder: ITransactionBuilder,
+    @inject(TYPES.ITransactionProcessor) transactionProcessor: ITransactionProcessor,
+    @inject(TYPES.ISender) sender: ISender,
+    @inject(TYPES.PaymentSummarizer) summarizer: ISummarizer<PaymentProcess>,
   ) {
     (this.paymentBuilder = paymentBuilder),
-    (this.transactionBuilder = transactionBuilder),
-    (this.transactionProcessor = transactionProcessor),
-    (this.sender = sender);
+      (this.transactionBuilder = transactionBuilder),
+      (this.transactionProcessor = transactionProcessor),
+      (this.sender = sender);
     this.summarizer = summarizer;
   }
 
@@ -57,18 +57,16 @@ export class PaymentProcessor implements IPaymentProcessor {
   private async calculateTotalPayoutFundsNeeded(paymentProcess: PaymentProcess, configuration: PaymentConfiguration) {
     let totalPayoutFundsNeeded = 0;
 
-    paymentProcess.payouts.map((t) => {
+    paymentProcess.payoutTransactions.map((t) => {
       totalPayoutFundsNeeded += t.amount + t.fee;
     });
 
     console.log(
-      `Total Funds Required for Payout = ${totalPayoutFundsNeeded} nanoMINA or ${
-        totalPayoutFundsNeeded / 1000000000
+      `Total Funds Required for Payout = ${totalPayoutFundsNeeded} nanoMINA or ${totalPayoutFundsNeeded / 1000000000
       } MINA`,
     );
     console.log(
-      `Fund via: mina_ledger_wallet send-payment --offline --network testnet --nonce FUNDERNONCE --fee 0.1 BIP44ACCOUNT FUNDING_FROM_ADDRESS ${
-        configuration.senderKeys.publicKey
+      `Fund via: mina_ledger_wallet send-payment --offline --network testnet --nonce FUNDERNONCE --fee 0.1 BIP44ACCOUNT FUNDING_FROM_ADDRESS ${configuration.senderKeys.publicKey
       } ${totalPayoutFundsNeeded / 1000000000}`,
     );
   }
@@ -76,8 +74,8 @@ export class PaymentProcessor implements IPaymentProcessor {
   private async isValid(config: PaymentConfiguration): Promise<boolean> {
     if (
       config.blockDataSource != 'ARCHIVEDB' &&
-            config.blockDataSource != 'MINAEXPLORER' &&
-            config.blockDataSource != 'API'
+      config.blockDataSource != 'MINAEXPLORER' &&
+      config.blockDataSource != 'API'
     ) {
       return false;
     }

--- a/src/core/payment/PaymentSummarizer.ts
+++ b/src/core/payment/PaymentSummarizer.ts
@@ -56,14 +56,14 @@ export class PaymentSummarizer implements ISummarizer<PaymentProcess> {
 
     const amountsum = getTotalAmountSum(base.payoutsBeforeExclusions);
 
-    const feesum = getTotalFeeSum(base.payouts);
+    const feesum = getTotalFeeSum(base.payoutTransactions);
 
     base.totals = {
       coinBaseSum: coinbasesum / 1000000000,
       feeTransferFromCoinBaseSum: feetransferfromcoinbasesum / 1000000000,
       userCommandTransactionFeeSum: usercommandtransactionfeessum / 1000000000,
       netCoinBaseReceived:
-                (coinbasesum - feetransferfromcoinbasesum + usercommandtransactionfeessum) / 1000000000,
+        (coinbasesum - feetransferfromcoinbasesum + usercommandtransactionfeessum) / 1000000000,
       payoutAmountsSum: amountsum / 1000000000,
       payoutFeesSum: feesum / 1000000000,
       payoutBurnSum: base.totalBurn / 1000000000,

--- a/src/core/payment/Tests/PaymentBuilder.test.ts
+++ b/src/core/payment/Tests/PaymentBuilder.test.ts
@@ -137,7 +137,7 @@ describe('Payment Builder Tests', () => {
         },
       ];
 
-      const expectedStorePayouts: PayoutDetails[] = [
+      const expectedPayoutDetails: PayoutDetails[] = [
         {
           blockHeight: 10,
           coinbase: 10,
@@ -203,8 +203,8 @@ describe('Payment Builder Tests', () => {
       const expectedPaymentProcess: PaymentProcess = {
         blocks: mockedBlocks,
         maximumHeight: 11,
-        payouts: expectedPayoutTransaction,
-        storePayout: expectedStorePayouts,
+        payoutTransactions: expectedPayoutTransaction,
+        payoutDetails: expectedPayoutDetails,
         totalPayoutFundsNeeded: 0,
         payoutsBeforeExclusions: [],
         totals: {
@@ -256,7 +256,7 @@ describe('Payment Builder Tests', () => {
         },
       ];
 
-      const expectedStorePayouts: PayoutDetails[] = [
+      const expectedPayoutDetails: PayoutDetails[] = [
         {
           blockHeight: 10,
           coinbase: 10,
@@ -322,8 +322,8 @@ describe('Payment Builder Tests', () => {
       const expectedPaymentProcess: PaymentProcess = {
         blocks: mockedBlocks,
         maximumHeight: 11,
-        payouts: expectedPayoutTransaction,
-        storePayout: expectedStorePayouts,
+        payoutTransactions: expectedPayoutTransaction,
+        payoutDetails: expectedPayoutDetails,
         totalPayoutFundsNeeded: 0,
         payoutsBeforeExclusions: [],
         totals: {

--- a/src/core/payment/Tests/PaymentSummarizer.test.ts
+++ b/src/core/payment/Tests/PaymentSummarizer.test.ts
@@ -53,9 +53,9 @@ describe('Payment Summarizer tests', () => {
       const process: PaymentProcess = {
         blocks: mockedBlocks,
         maximumHeight: 1,
-        payouts: [],
+        payoutTransactions: [],
         payoutsBeforeExclusions: [],
-        storePayout: [],
+        payoutDetails: [],
         totalPayoutFundsNeeded: 0,
         totalPayouts: 0,
         totalBurn: 0,

--- a/src/core/payment/Tests/TransactionBuilder.test.ts
+++ b/src/core/payment/Tests/TransactionBuilder.test.ts
@@ -18,8 +18,8 @@ describe('Transaction Builder Tests', () => {
       const mockPaymentProcess: PaymentProcess = {
         blocks: [],
         maximumHeight: 1,
-        payouts: [],
-        storePayout: [],
+        payoutTransactions: [],
+        payoutDetails: [],
         totalPayoutFundsNeeded: 11,
         payoutsBeforeExclusions: [],
         totalPayouts: 0,

--- a/src/core/payoutCalculator/Model.ts
+++ b/src/core/payoutCalculator/Model.ts
@@ -59,8 +59,8 @@ export interface IPayoutCalculator {
         configuredMemo: string,
     ): Promise<
         [
-            payoutJson: PayoutTransaction[],
-            storePayout: PayoutDetails[],
+            payoutTransactions: PayoutTransaction[],
+            payoutDetails: PayoutDetails[],
             blocksIncluded: number[],
             totalPayout: number,
             totalSuperchargedToBurn: number,

--- a/src/core/transaction/TransactionBuilder.ts
+++ b/src/core/transaction/TransactionBuilder.ts
@@ -15,10 +15,10 @@ export class TransactionBuilder implements ITransactionBuilder {
   async build(paymentProcess: PaymentProcess, config: PaymentConfiguration): Promise<PayoutTransaction[]> {
     // Aggregate to a single transaction per key and track the total for funding transaction
 
-    const { payouts, storePayout } = paymentProcess;
+    const { payoutTransactions, payoutDetails } = paymentProcess;
 
     let transactions: PayoutTransaction[] = [
-      ...payouts
+      ...payoutTransactions
         .reduce((r, o) => {
           const summaryGrouping = `${o.publicKey}:${o.summaryGroup}`;
           const item: PayoutTransaction =
@@ -42,7 +42,7 @@ export class TransactionBuilder implements ITransactionBuilder {
     ];
 
     if (config.verbose) {
-      console.table(storePayout);
+      console.table(payoutDetails);
       /*, [
                 'publicKey',
                 'blockHeight',
@@ -71,7 +71,7 @@ export class TransactionBuilder implements ITransactionBuilder {
 
     console.table(transactions);
 
-    paymentProcess.payouts = transactions;
+    paymentProcess.payoutTransactions = transactions;
 
     return transactions;
   }

--- a/src/core/transaction/TransactionProcessor.ts
+++ b/src/core/transaction/TransactionProcessor.ts
@@ -15,7 +15,7 @@ export class TransactionProcessor implements ITransactionProcessor {
   async write(config: PaymentConfiguration, paymentProcess: PaymentProcess): Promise<void> {
     const runDateTime = new Date();
 
-    const { storePayout, maximumHeight, totalPayoutFundsNeeded, payouts } = paymentProcess;
+    const { payoutDetails, maximumHeight, totalPayoutFundsNeeded, payoutTransactions } = paymentProcess;
 
     const { minimumHeight } = config;
 
@@ -26,7 +26,7 @@ export class TransactionProcessor implements ITransactionProcessor {
       maximumHeight,
     );
 
-    this.fileWriter.write(payoutTransactionsFileName, JSON.stringify(payouts));
+    this.fileWriter.write(payoutTransactionsFileName, JSON.stringify(payoutTransactions));
 
     const payoutDetailsFileName = this.generateOutputFileName(
       'payout_details',
@@ -35,7 +35,7 @@ export class TransactionProcessor implements ITransactionProcessor {
       maximumHeight,
     );
 
-    this.fileWriter.write(payoutDetailsFileName, JSON.stringify(storePayout));
+    this.fileWriter.write(payoutDetailsFileName, JSON.stringify(payoutDetails));
   }
 
   private generateOutputFileName(

--- a/src/core/transaction/TransactionSender.ts
+++ b/src/core/transaction/TransactionSender.ts
@@ -26,7 +26,7 @@ export class TransactionSender implements ISender {
         });
         paidblockStream.end();
       } else {
-        console.error(`ERROR: HASHES DON'T MATCH. Expected: ${payoutHash} Calculated: ${calculatedHash}`);
+        console.error(`\x1b[41mERROR: HASHES DON'T MATCH. Expected: ${payoutHash} Calculated: ${calculatedHash}\x1b[0m`);
       }
     } else {
       console.log(`PAYOUT HASH: ${calculatedHash}`);

--- a/src/core/transaction/TransactionSender.ts
+++ b/src/core/transaction/TransactionSender.ts
@@ -14,7 +14,7 @@ export class TransactionSender implements ISender {
     const { blocks, payoutTransactions } = paymentProcess;
 
     //const calculatedHash = hash(paymentProcess.payoutDetails, { algorithm: 'sha1' });
-    const calculatedHash = createHash('md5').update(paymentProcess.payoutDetails.toString()).digest('hex');
+    const calculatedHash = createHash('sha1').update(paymentProcess.payoutDetails.toString()).digest('hex');
 
     if (payoutHash) {
       console.log(`### Processing signed payout for hash ${payoutHash}...`);

--- a/src/core/transaction/TransactionSender.ts
+++ b/src/core/transaction/TransactionSender.ts
@@ -14,7 +14,7 @@ export class TransactionSender implements ISender {
     const { blocks, payoutTransactions } = paymentProcess;
 
     //const calculatedHash = hash(paymentProcess.payoutDetails, { algorithm: 'sha1' });
-    const calculatedHash = createHash('sha1').update(paymentProcess.payoutDetails.toString()).digest('hex');
+    const calculatedHash = createHash('sha1').update(JSON.stringify(paymentProcess.payoutDetails)).digest('hex');
 
     if (payoutHash) {
       console.log(`### Processing signed payout for hash ${payoutHash}...`);


### PR DESCRIPTION
Improve var names for clarity (payouts->payoutTransactions and storePayout->payoutDetails)

Add sort on payoutTransactions by amount desc - this sort standardizes sort order across data sources and returns to amount-sorted behavior in prior versions. (Requested by multiple operators.)

Consolidated hashing libs to just use node:crypto since it is already required for the MF memo, will now use same lib for the payout hash. 

Improved hash mismatch error to show different values.

