### PR TITLE
Compare-datasources

### DIFF
--- a/src/core/dataProvider/dataprovider-api/block-queries-api.ts
+++ b/src/core/dataProvider/dataprovider-api/block-queries-api.ts
@@ -9,7 +9,7 @@ if (!baseUrl) {
 export async function getLatestHeight(): Promise<number> {
   const response = await fetch(`${baseUrl}/consensus`);
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+    throw new Error(`HTTP error! ${baseUrl}/consensus returned status: ${response.status} ${response.statusText}`);
   }
   const responseData = await response.json();
 
@@ -19,7 +19,7 @@ export async function getLatestHeight(): Promise<number> {
 export async function getMinMaxBlocksByEpoch(epoch: number, fork: number): Promise<{ min: number; max: number }> {
   const response = await fetch(`${baseUrl}/epoch/${epoch}?fork=${fork}`);
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+    throw new Error(`HTTP error! ${baseUrl}/epoch/${epoch}?fork=${fork} returned status: ${response.status} ${response.statusText}`);
   }
   const responseData = await response.json();
   console.log(responseData);
@@ -29,7 +29,7 @@ export async function getMinMaxBlocksByEpoch(epoch: number, fork: number): Promi
 export async function getBlocks(key: string, minHeight: number, maxHeight: number): Promise<Blocks> {
   const response = await fetch(`${baseUrl}/blocks?key=${key}&minHeight=${minHeight}&maxHeight=${maxHeight}`);
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`);
+    throw new Error(`HTTP error! ${baseUrl}/blocks?key=${key}&minHeight=${minHeight}&maxHeight=${maxHeight} returned status: ${response.status} ${response.statusText}`);
   }
   const responseData = await response.json();
   let blocks = responseData.blocks as Blocks;

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -58,6 +58,7 @@ export class PaymentBuilder implements IPaymentBuilder {
     console.log(`Processing mina pool payout for block producer key: ${stakingPoolPublicKey}`);
 
     const blocks: Block[] = await blockProvider.getBlocks(stakingPoolPublicKey, minimumHeight, maximumHeight);
+    blocks.sort((a, b) => a.blockheight - b.blockheight);
 
     const payoutTransactions: PayoutTransaction[] = [];
 
@@ -73,7 +74,6 @@ export class PaymentBuilder implements IPaymentBuilder {
         console.log(`### Calculating payouts for ledger ${ledgerHash}`);
 
         const ledger = await stakesProvider.getStakes(ledgerHash, stakingPoolPublicKey);
-
         console.log(`The pool total staking balance is ${ledger.totalStakingBalance}`);
 
         const ledgerBlocks = blocks.filter((x) => x.stakingledgerhash == ledgerHash);

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -119,14 +119,11 @@ export class PaymentBuilder implements IPaymentBuilder {
       }),
     ).then(async () => {
       // added a sort because these payout details are hashed and need to be in a reliable order
-      payoutTransactions.sort(function (p1: PayoutTransaction, p2: PayoutTransaction) {
-        if (p1.amount > p2.amount) {
-          return -1;
+      payoutTransactions.sort((p1: PayoutTransaction, p2: PayoutTransaction) => {
+        if (p1.amount !== p2.amount) {
+          return p2.amount - p1.amount; // sort by amount in descending order
         }
-        if (p1.amount < p2.amount) {
-          return 1;
-        }
-        return 0;
+        return p1.publicKey.localeCompare(p2.publicKey); // sort by publicKey in ascending order if amounts are equal
       });
       payoutDetails.sort(function (p1: PayoutDetails, p2: PayoutDetails) {
         if (p1.blockHeight + p1.publicKey < p2.blockHeight + p2.publicKey) {


### PR DESCRIPTION
Include API endpoint URL in error messages.

Sort blocks when received from data provider to ensure rounding variations accumulate the same way.

Change payout transactions sort order to sort by amount then by public key so it is deterministic.

Now all data sources should result in the same hash for a given payout run. 