### PR TITLE
Allow user-specified payout calculator 

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASENAME
 
 -   Set `PAYOUT_DATA_PROVIDER_API_ENDPOINT=https://api.minastakes.com` or to the url of the preferred data provider.
 
+-   Set `PAYOUT_CALCULATOR=postSuperChargeCommonShareFees` (default) for the calculator that will have the Pool keep all fees. Valid calculators include: 'postSuperChargeShareFees', 'postSuperChargeKeepFees', 'postSuperChargeCommonShareFees', or Pre-Fork: 'isolateSuperCharge', 'original'
+
 ## Providing the Staking Ledgers
 
 -   Export the staking ledger and place it in src/data/ledger directory. You can export the current staking ledger with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-payout",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "",
   "engines": {
     "node": ">=18.18.0"

--- a/sample.env
+++ b/sample.env
@@ -36,3 +36,5 @@ MINAEXPLORER_GRAPHQL_ENDPOINT=https://graphql.minaexplorer.com
 PAYOUT_DATA_PROVIDER_API_ENDPOINT=https://api.minastakes.com
 
 DO_NOT_SAVE_TRANSACTION_DETAILS=FALSE
+
+PAYOUT_CALCULATOR=postSuperChargeCommonShareFees #VALID VALUES: 'postSuperChargeShareFees', 'postSuperChargeKeepFees', 'postSuperChargeCommonShareFees', or Pre-Fork: 'isolateSuperCharge', 'original'

--- a/src/configuration/ConfigurationManager.ts
+++ b/src/configuration/ConfigurationManager.ts
@@ -36,6 +36,7 @@ export class ConfigurationManager {
       burnAddress: 'B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X',
       doNotTransmit: args.donottransmit || false,
       doNotSaveTransactionDetails: (process.env.DO_NOT_SAVE_TRANSACTION_DETAILS?.toLowerCase() === 'true') || false,
+      payoutCalculator: process.env.PAYOUT_CALCULATOR || '',
     };
 
     await this.validate();
@@ -92,6 +93,9 @@ export class ConfigurationManager {
     if (this.Setup.fork == 1 && (this.Setup.blockDataSource === 'ARCHIVEDB' || this.Setup.blockDataSource === 'MINAEXPLORER')) {
       msg += 'ERROR: Fork 1 is not currently supported by ARCHIVEDB or MINAEXPLORER data sources.';
     }
+    if (!['postSuperChargeShareFees', 'postSuperChargeKeepFees', 'postSuperChargeCommonShareFees', 'isolateSuperCharge', 'original'].includes(this.Setup.payoutCalculator)) {
+      msg += 'ERROR: Invalid payout calculator specified. Must be one of postSuperChargeShareFees, postSuperChargeKeepFees, postSuperChargeCommonShareFees, isolateSuperCharge, or original';
+    }
     if (msg !== '') {
       console.log('\x1b[31m%s\x1b[0m', msg);
       process.exit(1);
@@ -100,11 +104,17 @@ export class ConfigurationManager {
       console.log('\x1b[31m%s\x1b[0m', '******************************');
       console.log('\x1b[31m%s\x1b[0m', 'WARNING: ARCHIVEDB data source only supports fork 0 currently. Please get in touch with @jrwashburn to notify that you need archivedb support for the hard fork.');
       console.log('\x1b[31m%s\x1b[0m', '******************************');
+      if (this.Setup.fork != 0) {
+        process.exit(1)
+      }
     }
     if (this.Setup.blockDataSource === 'MINAEXPLORER') {
       console.log('\x1b[31m%s\x1b[0m', '******************************');
       console.log('\x1b[31m%s\x1b[0m', 'WARNING: MINAEXPLORER data source will be deprecated at the hard fork. Switch to alternative api providers such as api.minastakes.com or the Mina Foundation equivalent.');
       console.log('\x1b[31m%s\x1b[0m', '******************************');
+      if (this.Setup.fork != 0) {
+        process.exit(1)
+      }
     }
   }
 }

--- a/src/configuration/Model.ts
+++ b/src/configuration/Model.ts
@@ -23,6 +23,7 @@ export interface PaymentConfiguration {
   stakingPoolPublicKey: string;
   verbose: boolean;
   doNotSaveTransactionDetails: boolean;
+  payoutCalculator: string;
 }
 
 export interface KeyedRate {

--- a/src/core/payment/PaymentBuilder.ts
+++ b/src/core/payment/PaymentBuilder.ts
@@ -29,7 +29,7 @@ export class PaymentBuilder implements IPaymentBuilder {
     const config = ConfigurationManager.Setup;
     const stakesProvider = this.stakeDataProviderFactory.build(config.blockDataSource);
     const blockProvider = this.blockDataProviderFactory.build(config.blockDataSource);
-    const payoutCalculator = this.payoutCalculatorFactory.build(config.fork);
+    const payoutCalculator = this.payoutCalculatorFactory.build(config.fork, config.payoutCalculator);
 
     const {
       configuredMaximum,

--- a/src/core/payoutCalculator/Model.ts
+++ b/src/core/payoutCalculator/Model.ts
@@ -69,5 +69,5 @@ export interface IPayoutCalculator {
 }
 
 export interface IPayoutCalculatorFactory<T> {
-    build(fork: number): T;
+    build(fork: number, payoutCalculator: string): T;
 }

--- a/src/core/payoutCalculator/PayoutCalculatorFactory.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorFactory.ts
@@ -1,15 +1,34 @@
 import { injectable } from 'inversify';
+import { PayoutCalculator } from './PayoutCalculator';
 import { PayoutCalculatorIsolateSuperCharge } from './PayoutCalculatorIsolateSuperCharge';
-import { PayoutCalculatorPostSuperCharge } from './PayoutCalculatorPostSuperCharge';
+import { PayoutCalculatorPostSuperChargeShareFees } from './PayoutCalculatorPostSuperChargeShareFees';
+import { PayoutCalculatorPostSuperChargeCommonShareFees } from './PayoutCalculatorPostSuperChargeCommonShareFees';
+import { PayoutCalculatorPostSuperChargeKeepFees } from './PayoutCalculatorPostSuperChargeKeepFees';
 import { IPayoutCalculatorFactory, IPayoutCalculator } from './Model';
 
+//valid payoutCalculator Values: ['postSuperChargeShareFees', 'postSuperChargeKeepFees', 'postSuperChargeCommonShareFees', 'isolateSuperCharge', 'original']
 @injectable()
 export class PayoutCalculatorFactory implements IPayoutCalculatorFactory<IPayoutCalculator> {
-  build(fork: number): IPayoutCalculator {
+  build(fork: number, payoutCalculator: string): IPayoutCalculator {
     if (fork == 0) {
-      return new PayoutCalculatorIsolateSuperCharge();
+      if (payoutCalculator === 'isolateSuperCharge') {
+        return new PayoutCalculatorIsolateSuperCharge();
+      }
+      if (payoutCalculator === 'original') {
+        return new PayoutCalculator();
+      }
+      throw new Error('Invalid payoutCalculator specified for fork 0');
     } else if (fork == 1) {
-      return new PayoutCalculatorPostSuperCharge();
+      if (payoutCalculator === 'postSuperChargeKeepFees') {
+        return new PayoutCalculatorPostSuperChargeKeepFees();
+      }
+      if (payoutCalculator === 'postSuperChargeShareFees') {
+        return new PayoutCalculatorPostSuperChargeShareFees();
+      }
+      if (payoutCalculator === 'postSuperChargeCommonShareFees') {
+        return new PayoutCalculatorPostSuperChargeCommonShareFees();
+      }
+      throw new Error('Invalid payoutCalculator specified for fork 1');
     } else {
       throw new Error(`Invalid fork value ${fork} not sure which calculator to use.`);
     }

--- a/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeCommonShareFees.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeCommonShareFees.ts
@@ -1,0 +1,213 @@
+import { injectable } from 'inversify';
+import { KeyedRate } from '../../configuration/Model';
+import { Block, Stake } from '../dataProvider/dataprovider-types';
+import { IPayoutCalculator, PayoutDetails, PayoutTransaction } from './Model';
+import { Decimal } from 'decimal.js';
+
+@injectable()
+export class PayoutCalculatorPostSuperChargeCommonShareFees implements IPayoutCalculator {
+  async getPayouts(
+    blocks: Block[],
+    stakers: Stake[],
+    totalStake: number,
+    defaultCommissionRate: number,
+    mfCommissionRate: number,
+    o1CommissionRate: number,
+    investorsCommissionRate: number,
+    commissionRates: KeyedRate,
+    burnRates: KeyedRate,
+    burnAddress: string,
+    bpKeyMd5Hash: string,
+    configuredMemo: string,
+  ): Promise<[
+    payoutTranaction: PayoutTransaction[],
+    payoutDetails: PayoutDetails[],
+    blocksIncluded: number[],
+    totalPayout: number,
+    totalSuperchargedToBurn: number,
+    totalNegotiatedBurn: number,
+  ]> {
+    console.log('Using Post Super Charge Payout Calculator');
+    //TODO: JC - Shared Logic must be moved into its own class, then isolate change in behaviors
+    // Initialize some stuff
+    const REGULARCOINBASE = 720000000000;
+    const blocksIncluded: number[] = [];
+    const payoutDetails: PayoutDetails[] = [];
+    let totalNegotiatedBurn = 0;
+
+    // for each block, calculate the effective stake of each staker
+    blocks.forEach((block: Block) => {
+      // Keep a log of all blocks we processed
+      blocksIncluded.push(block.blockheight);
+
+      if (typeof block.coinbase === 'undefined' || block.coinbase == 0) {
+        // no coinbase, don't need to do anything
+      } else {
+        const poolStakes: { [key: string]: { stake: number } } = {};
+        const npsBlockReward = block.coinbase;
+        const commonBlockReward = block.feetransfertoreceiver - block.feetransferfromcoinbase;
+
+        let npsPoolStakes = new Decimal(0.0);
+        let commonPoolStakes = new Decimal(0.0);
+
+        // Determine the non-participating and common pool weighting for each staker
+        stakers.forEach((staker: Stake) => {
+          const stakerStake = new Decimal(staker.stakingBalance);
+          npsPoolStakes = npsPoolStakes.plus(stakerStake);
+          commonPoolStakes = staker.shareClass.shareClass == 'Common' ? commonPoolStakes.plus(stakerStake) : commonPoolStakes;
+          poolStakes[staker.publicKey] = { stake: stakerStake.toNumber() };
+        });
+
+        // Sense check the effective pool stakes must be at least equal to total_staking_balance and less than 2x
+        if (npsPoolStakes.toNumber() !== totalStake || commonPoolStakes.toNumber() > totalStake) {
+          throw new Error(`Sum of pool shares must be equal to total staked amount: npsPoolStakes: ${npsPoolStakes.toNumber()} commonPoolStakes: ${commonPoolStakes.toNumber()} totalStake: ${totalStake}`);
+        }
+        if (block.coinbase != REGULARCOINBASE) {
+          throw new Error(`Coinbase must be equal to ${REGULARCOINBASE} but is ${block.coinbase}`);
+        }
+
+        stakers.forEach((staker: Stake) => {
+          const stakerNpsPoolWeight = npsPoolStakes.greaterThan(0) ? poolStakes[staker.publicKey].stake / npsPoolStakes.toNumber() : 0;
+          const stakerCommonPoolWeight = commonPoolStakes.greaterThan(0) && staker.shareClass.shareClass == 'Common' ? poolStakes[staker.publicKey].stake / commonPoolStakes.toNumber() : 0;
+          const commissionRate = commissionRates[staker.publicKey]
+            ? commissionRates[staker.publicKey].rate
+            : defaultCommissionRate;
+          let blockTotal = 0;
+
+          if (staker.shareClass.shareClass == 'Common') {
+            blockTotal =
+              Math.floor((1 - commissionRate) * npsBlockReward * stakerNpsPoolWeight) +
+              Math.floor((1 - commissionRate) * commonBlockReward * stakerCommonPoolWeight);
+          } else if (staker.shareClass.shareClass == 'NPS') {
+            if (staker.shareClass.shareOwner == 'MF') {
+              blockTotal = Math.floor(
+                (1 - mfCommissionRate) * npsBlockReward * stakerNpsPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'O1') {
+              blockTotal = Math.floor(
+                (1 - o1CommissionRate) * npsBlockReward * stakerNpsPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'INVEST') {
+              blockTotal = Math.floor(
+                (1 - investorsCommissionRate) * npsBlockReward * stakerNpsPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'BURN') {
+              blockTotal = Math.floor(
+                (1 - commissionRate) * npsBlockReward * stakerNpsPoolWeight);
+            } else {
+              throw new Error(
+                'NPS shares should be MF or O1 or INVEST or BURN. Found NPS Shares with other owner.',
+              );
+            }
+          } else {
+            throw new Error(
+              'Shares should be common or non-participating. Found shares with other shareClass.',
+            );
+          }
+
+          // After calculating the block award, if the delegate has a fractional burn, move some of the blocktotal to the burn address
+          const negotiatedBurnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
+          const negotiatedBurnAmount = Math.floor(blockTotal * negotiatedBurnRate);
+          totalNegotiatedBurn += negotiatedBurnAmount;
+          blockTotal -= negotiatedBurnAmount;
+          staker.total += blockTotal;
+
+          // Store this data in a structured format for later querying and for the payment script, handled seperately
+          // Must keep effective weights for different pools for backward compatibility
+          payoutDetails.push({
+            publicKey: staker.publicKey,
+            owner: staker.shareClass.shareOwner,
+            blockHeight: block.blockheight,
+            globalSlot: block.globalslotsincegenesis,
+            publicKeyUntimedAfter: staker.untimedAfterSlot,
+            winnerShareOwner: '',
+            shareClass: staker.shareClass,
+            stateHash: block.statehash,
+            effectiveNPSPoolWeighting: 0,
+            effectiveNPSPoolStakes: 0,
+            effectiveCommonPoolWeighting: stakerCommonPoolWeight,
+            effectiveCommonPoolStakes: poolStakes[staker.publicKey].stake,
+            effectiveSuperchargedPoolWeighting: 0,
+            effectiveSuperchargedPoolStakes: 0,
+            stakingBalance: staker.stakingBalance,
+            sumEffectiveNPSPoolStakes: 0,
+            sumEffectiveCommonPoolStakes: commonPoolStakes.toNumber(),
+            sumEffectiveSuperchargedPoolStakes: 0,
+            superchargedWeightingDiscount: 0,
+            dateTime: block.blockdatetime,
+            coinbase: block.coinbase,
+            totalRewards: npsBlockReward + commonBlockReward,
+            totalRewardsToBurn: 0,
+            totalRewardsNPSPool: 0,
+            totalRewardsCommonPool: commonBlockReward,
+            totalRewardsSuperchargedPool: 0,
+            payout: blockTotal,
+            isEffectiveSuperCharge: true,
+          });
+        });
+        if (totalNegotiatedBurn > 0) {
+          payoutDetails.push({
+            publicKey: burnAddress,
+            owner: 'BURN',
+            blockHeight: block.blockheight,
+            globalSlot: block.globalslotsincegenesis,
+            publicKeyUntimedAfter: 0,
+            winnerShareOwner: '',
+            shareClass: { shareClass: 'BURN', shareOwner: 'BURN' },
+            stateHash: block.statehash,
+            stakingBalance: 0,
+            effectiveNPSPoolWeighting: 0,
+            effectiveNPSPoolStakes: 0,
+            effectiveCommonPoolWeighting: 0,
+            effectiveCommonPoolStakes: 0,
+            sumEffectiveNPSPoolStakes: 0,
+            sumEffectiveCommonPoolStakes: 0,
+            superchargedWeightingDiscount: 0,
+            dateTime: block.blockdatetime,
+            coinbase: 0,
+            totalRewards: 0,
+            totalRewardsToBurn: totalNegotiatedBurn,
+            totalRewardsNPSPool: 0,
+            totalRewardsCommonPool: 0,
+            payout: 0,
+            isEffectiveSuperCharge: false,
+            effectiveSuperchargedPoolWeighting: 0,
+            effectiveSuperchargedPoolStakes: 0,
+            sumEffectiveSuperchargedPoolStakes: 0,
+            totalRewardsSuperchargedPool: 0,
+          });
+        }
+      }
+    });
+
+    const payoutTransactions: PayoutTransaction[] = [];
+    let totalPayout = 0;
+    stakers.forEach((staker: Stake) => {
+      const amount = staker.total;
+      if (amount > 0) {
+        payoutTransactions.push({
+          publicKey: staker.publicKey,
+          amount: amount,
+          fee: 0,
+          amountMina: 0,
+          feeMina: 0,
+          memo:
+            staker.shareClass.shareOwner === 'MF' || staker.shareClass.shareOwner === 'INVEST'
+              ? bpKeyMd5Hash
+              : configuredMemo,
+          summaryGroup: 0,
+        });
+        totalPayout += amount;
+      }
+    });
+    if (totalNegotiatedBurn > 0) {
+      payoutTransactions.push({
+        publicKey: burnAddress,
+        amount: totalNegotiatedBurn,
+        fee: 0,
+        amountMina: 0,
+        feeMina: 0,
+        memo: configuredMemo,
+        summaryGroup: 2,
+      });
+    }
+    return [payoutTransactions, payoutDetails, blocksIncluded, totalPayout, 0, totalNegotiatedBurn];
+  }
+}

--- a/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeKeepFees.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeKeepFees.ts
@@ -5,7 +5,7 @@ import { IPayoutCalculator, PayoutDetails, PayoutTransaction } from './Model';
 import { Decimal } from 'decimal.js';
 
 @injectable()
-export class PayoutCalculatorPostSuperCharge implements IPayoutCalculator {
+export class PayoutCalculatorPostSuperChargeKeepFees implements IPayoutCalculator {
   async getPayouts(
     blocks: Block[],
     stakers: Stake[],
@@ -44,7 +44,7 @@ export class PayoutCalculatorPostSuperCharge implements IPayoutCalculator {
         // no coinbase, don't need to do anything
       } else {
         const poolStakes: { [key: string]: { stake: number } } = {};
-        const thisBlockReward = block.coinbase + block.feetransfertoreceiver - block.feetransferfromcoinbase;
+        const thisBlockReward = block.coinbase; // Intentionally excluding fees from the payout, they are kept for the pool owner
         let sumPoolStakes = new Decimal(0.0);
 
         // Determine the non-participating and common pool weighting for each staker

--- a/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeShareFees.ts
+++ b/src/core/payoutCalculator/PayoutCalculatorPostSuperChargeShareFees.ts
@@ -1,0 +1,207 @@
+import { injectable } from 'inversify';
+import { KeyedRate } from '../../configuration/Model';
+import { Block, Stake } from '../dataProvider/dataprovider-types';
+import { IPayoutCalculator, PayoutDetails, PayoutTransaction } from './Model';
+import { Decimal } from 'decimal.js';
+
+@injectable()
+export class PayoutCalculatorPostSuperChargeShareFees implements IPayoutCalculator {
+  async getPayouts(
+    blocks: Block[],
+    stakers: Stake[],
+    totalStake: number,
+    defaultCommissionRate: number,
+    mfCommissionRate: number,
+    o1CommissionRate: number,
+    investorsCommissionRate: number,
+    commissionRates: KeyedRate,
+    burnRates: KeyedRate,
+    burnAddress: string,
+    bpKeyMd5Hash: string,
+    configuredMemo: string,
+  ): Promise<[
+    payoutTranaction: PayoutTransaction[],
+    payoutDetails: PayoutDetails[],
+    blocksIncluded: number[],
+    totalPayout: number,
+    totalSuperchargedToBurn: number,
+    totalNegotiatedBurn: number,
+  ]> {
+    console.log('Using Post Super Charge Payout Calculator');
+    //TODO: JC - Shared Logic must be moved into its own class, then isolate change in behaviors
+    // Initialize some stuff
+    const REGULARCOINBASE = 720000000000;
+    const blocksIncluded: number[] = [];
+    const payoutDetails: PayoutDetails[] = [];
+    let totalNegotiatedBurn = 0;
+
+    // for each block, calculate the effective stake of each staker
+    blocks.forEach((block: Block) => {
+      // Keep a log of all blocks we processed
+      blocksIncluded.push(block.blockheight);
+
+      if (typeof block.coinbase === 'undefined' || block.coinbase == 0) {
+        // no coinbase, don't need to do anything
+      } else {
+        const poolStakes: { [key: string]: { stake: number } } = {};
+        const thisBlockReward = block.coinbase + block.feetransfertoreceiver - block.feetransferfromcoinbase;
+        let sumPoolStakes = new Decimal(0.0);
+
+        // Determine the non-participating and common pool weighting for each staker
+        stakers.forEach((staker: Stake) => {
+          const stakerStake = new Decimal(staker.stakingBalance);
+          sumPoolStakes = sumPoolStakes.plus(stakerStake);
+          poolStakes[staker.publicKey] = { stake: stakerStake.toNumber() };
+        });
+
+        // Sense check the effective pool stakes must be at least equal to total_staking_balance and less than 2x
+        if (sumPoolStakes.toNumber() !== totalStake) {
+          throw new Error('Sum of pool shares must be equal to total staked amount');
+        }
+        if (block.coinbase != REGULARCOINBASE) {
+          throw new Error(`Coinbase must be equal to ${REGULARCOINBASE} but is ${block.coinbase}`);
+        }
+
+        stakers.forEach((staker: Stake) => {
+          const stakerPoolWeight = sumPoolStakes.greaterThan(0) ? poolStakes[staker.publicKey].stake / sumPoolStakes.toNumber() : 0;
+          const commissionRate = commissionRates[staker.publicKey]
+            ? commissionRates[staker.publicKey].rate
+            : defaultCommissionRate;
+          let blockTotal = 0;
+
+          if (staker.shareClass.shareClass == 'Common') {
+            blockTotal =
+              Math.floor((1 - commissionRate) * thisBlockReward * stakerPoolWeight);
+          } else if (staker.shareClass.shareClass == 'NPS') {
+            if (staker.shareClass.shareOwner == 'MF') {
+              blockTotal = Math.floor(
+                (1 - mfCommissionRate) * thisBlockReward * stakerPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'O1') {
+              blockTotal = Math.floor(
+                (1 - o1CommissionRate) * thisBlockReward * stakerPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'INVEST') {
+              blockTotal = Math.floor(
+                (1 - investorsCommissionRate) * thisBlockReward * stakerPoolWeight);
+            } else if (staker.shareClass.shareOwner == 'BURN') {
+              blockTotal = Math.floor(
+                (1 - commissionRate) * thisBlockReward * stakerPoolWeight);
+            } else {
+              throw new Error(
+                'NPS shares should be MF or O1 or INVEST or BURN. Found NPS Shares with other owner.',
+              );
+            }
+          } else {
+            throw new Error(
+              'Shares should be common or non-participating. Found shares with other shareClass.',
+            );
+          }
+
+          // After calculating the block award, if the delegate has a fractional burn, move some of the blocktotal to the burn address
+          const negotiatedBurnRate = burnRates[staker.publicKey] ? burnRates[staker.publicKey].rate : 0;
+          const negotiatedBurnAmount = Math.floor(blockTotal * negotiatedBurnRate);
+          totalNegotiatedBurn += negotiatedBurnAmount;
+          blockTotal -= negotiatedBurnAmount;
+          staker.total += blockTotal;
+
+          // Store this data in a structured format for later querying and for the payment script, handled seperately
+          // Must keep effective weights for different pools for backward compatibility
+          payoutDetails.push({
+            publicKey: staker.publicKey,
+            owner: staker.shareClass.shareOwner,
+            blockHeight: block.blockheight,
+            globalSlot: block.globalslotsincegenesis,
+            publicKeyUntimedAfter: staker.untimedAfterSlot,
+            winnerShareOwner: '',
+            shareClass: staker.shareClass,
+            stateHash: block.statehash,
+            effectiveNPSPoolWeighting: 0,
+            effectiveNPSPoolStakes: 0,
+            effectiveCommonPoolWeighting: stakerPoolWeight,
+            effectiveCommonPoolStakes: poolStakes[staker.publicKey].stake,
+            effectiveSuperchargedPoolWeighting: 0,
+            effectiveSuperchargedPoolStakes: 0,
+            stakingBalance: staker.stakingBalance,
+            sumEffectiveNPSPoolStakes: 0,
+            sumEffectiveCommonPoolStakes: sumPoolStakes.toNumber(),
+            sumEffectiveSuperchargedPoolStakes: 0,
+            superchargedWeightingDiscount: 0,
+            dateTime: block.blockdatetime,
+            coinbase: block.coinbase,
+            totalRewards: thisBlockReward,
+            totalRewardsToBurn: 0,
+            totalRewardsNPSPool: 0,
+            totalRewardsCommonPool: thisBlockReward,
+            totalRewardsSuperchargedPool: 0,
+            payout: blockTotal,
+            isEffectiveSuperCharge: true,
+          });
+        });
+        if (totalNegotiatedBurn > 0) {
+          payoutDetails.push({
+            publicKey: burnAddress,
+            owner: 'BURN',
+            blockHeight: block.blockheight,
+            globalSlot: block.globalslotsincegenesis,
+            publicKeyUntimedAfter: 0,
+            winnerShareOwner: '',
+            shareClass: { shareClass: 'BURN', shareOwner: 'BURN' },
+            stateHash: block.statehash,
+            stakingBalance: 0,
+            effectiveNPSPoolWeighting: 0,
+            effectiveNPSPoolStakes: 0,
+            effectiveCommonPoolWeighting: 0,
+            effectiveCommonPoolStakes: 0,
+            sumEffectiveNPSPoolStakes: 0,
+            sumEffectiveCommonPoolStakes: 0,
+            superchargedWeightingDiscount: 0,
+            dateTime: block.blockdatetime,
+            coinbase: 0,
+            totalRewards: 0,
+            totalRewardsToBurn: totalNegotiatedBurn,
+            totalRewardsNPSPool: 0,
+            totalRewardsCommonPool: 0,
+            payout: 0,
+            isEffectiveSuperCharge: false,
+            effectiveSuperchargedPoolWeighting: 0,
+            effectiveSuperchargedPoolStakes: 0,
+            sumEffectiveSuperchargedPoolStakes: 0,
+            totalRewardsSuperchargedPool: 0,
+          });
+        }
+      }
+    });
+
+    const payoutTransactions: PayoutTransaction[] = [];
+    let totalPayout = 0;
+    stakers.forEach((staker: Stake) => {
+      const amount = staker.total;
+      if (amount > 0) {
+        payoutTransactions.push({
+          publicKey: staker.publicKey,
+          amount: amount,
+          fee: 0,
+          amountMina: 0,
+          feeMina: 0,
+          memo:
+            staker.shareClass.shareOwner === 'MF' || staker.shareClass.shareOwner === 'INVEST'
+              ? bpKeyMd5Hash
+              : configuredMemo,
+          summaryGroup: 0,
+        });
+        totalPayout += amount;
+      }
+    });
+    if (totalNegotiatedBurn > 0) {
+      payoutTransactions.push({
+        publicKey: burnAddress,
+        amount: totalNegotiatedBurn,
+        fee: 0,
+        amountMina: 0,
+        feeMina: 0,
+        memo: configuredMemo,
+        summaryGroup: 2,
+      });
+    }
+    return [payoutTransactions, payoutDetails, blocksIncluded, totalPayout, 0, totalNegotiatedBurn];
+  }
+}


### PR DESCRIPTION
There are now 3 options for how fees are handled: shared among all stakers, shared exclusively by non-MF/O1/Investor stakers, or kept by the pool owner.

Pool owners can control this by setting new environment variable PAYOUT_CALCULATOR to postSuperChargeShareFees, postSuperChargeKeepFees, or postSuperChargeCommonShareFees.